### PR TITLE
Ensure we require https with uaa

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -318,6 +318,7 @@ properties:
     issuer: (( url ))
 
     no_ssl: false
+    require_https: true
 
     scim:
       userids_enabled: (( merge || true ))


### PR DESCRIPTION
This is helpful for secure cookies
Config.xml
https://github.com/cloudfoundry/uaa/blob/85fbe8ee080c50a86ac2f90fcdc705e3db6e82eb/uaa/src/main/webapp/WEB-INF/spring-servlet.xml#L41

the secure cookie config class
https://github.com/cloudfoundry/uaa/blob/616e8bcc58f9bc16f9d9ec806da1b0bf0f5dae85/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSessionCookieConfig.java#L36