### PR TITLE
enable route services

### DIFF
--- a/cf-secrets-example.yml
+++ b/cf-secrets-example.yml
@@ -99,6 +99,7 @@ properties:
     user: NATS_USER
     password: NATS_PASSWORD
   router:
+    route_services_secret: ROUTE_SERVICES_SECRET
     status:
       user: ROUTER_USER
       password: ROUTER_PASSWORD


### PR DESCRIPTION
As [explained in Slack](https://18f.slack.com/archives/cloud-gov/p1462585445000428), I am interested in experimenting with [Route Services](http://docs.cloudfoundry.org/services/route-services.html). It _seems_ all that's required to [enable them](http://docs.cloudfoundry.org/services/route-services.html#enabling-route-services-in-cloudfoundry) is providing this secret, which I guess then needs to be updated in the _actual_ credentials file(s) stored in S3?

I ran into a bunch of `unresolved nodes` errors when trying to run spiff locally, so wasn't able to fully verify I did this right. Would love to pair with someone and test this for real!