### PR TITLE
Switch tests from 2 -> 6:

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -43,6 +43,9 @@ properties:
   ssl:
     skip_cert_verify: (( merge || false ))
 
+  acceptance_tests:
+    nodes: 6
+
   blobstore:
     port: (( merge || 80 ))
     admin_users: (( merge || nil ))


### PR DESCRIPTION
-  The number of parallel test executors to spawn. The larger the number the higher the stress on the system.