### PR TITLE
Remove common releases from the CF deployment

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -8,22 +8,12 @@ meta:
   releases:
   - name: cf
     version: 218
-  - name: fisma
-    version: latest
-  - name: newrelic
-    version: latest
   - name: collectd
     version: latest
   - name: 18f-cf
     version: latest
   - name: secureproxy
     version: 7
-  - name: tripwire
-    version: latest
-  - name: awslogs
-    version: latest
-  - name: nessus-agent
-    version: latest
 
 name: (( meta.environment ))
 

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -127,14 +127,9 @@ jobs:
       manifest: cf-stage-manifest/staging-manifest.yml
       releases:
         - cf-release/*.tgz
-        - cg-s3-nessus-agent-release/*.tgz
-        - cg-s3-fisma-release/*.tgz
-        - cg-s3-newrelic-release/*.tgz
         - cg-s3-collectd-release/*.tgz
         - cg-s3-18f-cf-release/*.tgz
         - cg-s3-secureproxy-release/*.tgz
-        - cg-s3-tripwire-release/*.tgz
-        - cg-s3-awslogs-release/*.tgz
       stemcells:
         - cf-stemcell/*.tgz
     on_success:
@@ -346,14 +341,9 @@ jobs:
       manifest: cf-prod-manifest/manifest.yml
       releases:
         - cf-release/*.tgz
-        - cg-s3-nessus-agent-release/*.tgz
-        - cg-s3-fisma-release/*.tgz
-        - cg-s3-newrelic-release/*.tgz
         - cg-s3-collectd-release/*.tgz
         - cg-s3-18f-cf-release/*.tgz
         - cg-s3-secureproxy-release/*.tgz
-        - cg-s3-tripwire-release/*.tgz
-        - cg-s3-awslogs-release/*.tgz
       stemcells:
         - cf-stemcell/*.tgz
     on_success:


### PR DESCRIPTION
This PR removes the fisma, nessus, tripwire, awslogs, and newrelic releases from the CF deployment, as they've [been moved to the bosh deployment ](https://github.com/18F/cg-deploy-bosh/commit/5b618338a7ec581dd7d6ab39711e1083a9c27377) since they are needed for all bosh managed VMs not just CF.

I left the resources in the pipeline as triggers so that we'll still update CF when a new version is pushed, I think that's the right thing to do, but I'm not sure.

This work is related to 18F/cg-atlas#57

Feedback appreciated