### PR TITLE
[WIP] Allow setting for "service domain" and "system domain"

### DIFF
--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -6,6 +6,8 @@ meta:
   environment: ~
 
   app_domains: (( merge ))
+  
+  service_domain: (( merge ))
 
   release:
     name: cf
@@ -46,6 +48,7 @@ meta:
     registration_interval: 20s
     uris:
     - (( "api." .properties.domain ))
+    - (( "api." .meta.service_domain ))
 
   api_consul_services:
     cloud_controller_ng: {}
@@ -159,6 +162,10 @@ meta:
     - (( "*.uaa." .properties.domain ))
     - (( "login." .properties.domain ))
     - (( "*.login." .properties.domain ))
+    - (( "login." .meta.service_domain )) 
+    - (( "*.login." .meta.service_domain ))
+    - (( "uaa." .meta.service_domain ))
+    - (( "*.uaa." .meta.service_domain ))
     # health_check:
     #   name: uaa-healthcheck
     #   script_path: /var/vcap/jobs/uaa/bin/health_check

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -1,5 +1,6 @@
 meta:
   environment: ~
+  service_domain: (( merge ))
   default_quota_definitions:
     default:
        memory_limit: 10240
@@ -135,7 +136,7 @@ properties:
 
     external_host: api
     external_port: 9022
-    srv_api_uri: (( "https://" external_host "." domain ))
+    srv_api_uri: (( "https://" external_host "." meta.service_domain ))
 
     bulk_api_password: (( merge ))
     internal_api_user: "internal_user"
@@ -274,7 +275,7 @@ properties:
     analytics:
       code: ~
       domain: ~
-    url: (( "https://login." domain ))
+    url: (( "https://login." meta.service_domain ))
     uaa_certificate: ~
     protocol: https
     brand: oss
@@ -297,9 +298,9 @@ properties:
       password: ~
 
     links:
-      home: (( "https://console." domain ))
-      passwd: (( "https://login." domain "/forgot_password" ))
-      signup: (( "https://login." domain "/" ))
+      home: (( "https://console." meta.service_domain ))
+      passwd: (( "https://login." meta.service_domain "/forgot_password" ))
+      signup: (( "https://login." meta.service_domain "/" ))
       network: ~
       signup-network: ~
 
@@ -307,11 +308,11 @@ properties:
 
     tiles:
     - name: console
-      login-link: (( "https://console." domain ))
+      login-link: (( "https://console." meta.service_domain ))
       image: https://18f-cloud-gov.s3.amazonaws.com/deck.jpg
       image-hover: https://18f-cloud-gov.s3.amazonaws.com/deck.jpg
     - name: Invite Users
-      login-link: (( "https://invite." domain ))
+      login-link: (( "https://invite." meta.service_domain ))
       image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHQAAAB0CAMAAABjROYVAAABwlBMVEUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADzhAbiAAAAlXRSTlMAAQIDBAUGBwgJCw0ODxAREhMUFRYXGBkaGxwdHh8gIiMlJicoKSorLC0uLzAxMjM0NTY3ODk7PEFCQ0ZHSUpLTE9QUVJWWFlbXF1fYmRnaWtsbW91d3h5fH6FhomLjI6PkZSVl5qbnZ6go6WmqKqrsLK0t7m6vMDBw8fIz9HT1dfZ2tze4OLk5ujp6+3v8fP19/n7/SSB24YAAAOhSURBVGje7drpXxJBGAfwH6ABFniWpFR2mJZlZdphapl2WGnaoZ12mh0mmUeaKV6ZpmmCz//bC0Ee3IPdZWd90f5e7WeZmS/u7jMzCIAdO3bs2Nmm+JtD0+skNOvToWY/I72vyKK88MTNomWyLEuBDbN4nSzMegAAvMtkaX57ALwki/Mc8JPl8aHZevQqQrGjtfqCPKEpqI3EqH7MxI7qxM9AjTFqGvF62S0e3ROvGsQvdFA8mhe3NtHS7UAvikf3S9BO8WiVBB0Vj3ZKUMoUjs5L0dOizSBJ0X7RaI8MSjkWFUwS+kws+lUWpYBI8yzJo2MCTc+KAkrt4tAQKaF0TJR5l5TRiKDbWk0qKK3mizCPkCpKf0vMN0ujKVCiC2abtRJCilKXw0zS0UVaUBpym2e6h0gFvbmWOLlYZJZZtJgYde2GBM0LRth7uWyOeYWXY7F0j5SH4Cpr0u1Mn3R282IMQg5F9jxrNJ6Vrpk1zob76Yc8Cvcwa7ZyKD3zMJ/ih91QQuF4yB+ylnTMW3ykBw4oo0AVe4ip12WUdL1nw6yd2TipiMI3wZqH/cZM/xQbZMKHVCicb/mbrDRinuKX6/VmHaigQBO/HR36zXu8f2PivCqKYjaPUEjnLjyTbxKS5jZ1NHnGnNO1xubPsa6DSbN4ChSOTtY1ek67eT4qqRTNKFATNbDaJa1jkeotr6ZGkTujeJ0U17FB1mVa8olBA4qMPjbEgoYtW4A/f58yYAQFWvmzfymVWcdbt8o00Iaiglf5E9Ub63jKt3cVMI7CH2ZDjarcWPcoazjpQzooXB/5oqj4aTKXL8UfFNYJzSjQxqfiMvk2xyMpbqdeFCf5iNflWrTw93UCZqDI4TPbG8m1c/Wwl2dVPs/rQpE5wIadKdxSnbPsxS9qq4M+FI7HvAbvsNpxJNXyI9Wq0okCDXzscEn89EG+RaB69TF0oyjhu2L6Vu0FvDW8OGnlAMxGsWuKVBPeCfNRZHxWM/syIAIF2pXNNg3djaEo/yNPLh2FOBQ7ZL866t4BkSgQGNhKDhRq7GocBYp6Oflur+aO6aCApz4UJSKKhuo8OrqlhwKANzvbq7NL+qiB2KiN2qiN2uh/hy7EDsrEo+Ux6hdGYkc/fKJN/2SMGsZ9sjwdid8BWJd9wHerzTHA+j81CADXrDWbNh6rVivN2/GHuXLRKnKB/RvE2TBiBTlcv+UrJldWrtife+VmuWDHjh07drYt/wDZpi7rUVKOBQAAAABJRU5ErkJggg=='
 
     saml: ~
@@ -325,7 +326,7 @@ properties:
     ssl:
       port: (( merge || 8443 ))
 
-    url: (( "https://uaa." domain ))
+    url: (( "https://uaa." meta.service_domain ))
     issuer: (( url ))
 
     no_ssl: false
@@ -384,7 +385,7 @@ properties:
         authorities: oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write
         secret: (( merge ))
         authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: (( properties.login.protocol "://login." domain ))
+        redirect-uri: (( properties.login.protocol "://login." meta.service_domain ))
         autoapprove: true
       notifications:
         secret: (( merge ))
@@ -434,7 +435,7 @@ properties:
         scope: scim.invite
         authorized-grant-types: authorization_code
         secret: (( merge ))
-        redirect-uri: (( "https://invite." domain "/oauth/login"))
+        redirect-uri: (( "https://invite." meta.service_domain "/oauth/login"))
         name: UAA Invite
         autoapprove: true
 


### PR DESCRIPTION
To deploy 237 we need to have some way of not shadowing the `system_domain`.

This allows the setting of `service_domain` that allows exposing urls for users that are more "convenient", like "api.cloud.gov" or "login.cloud.gov".