### PR TITLE
Staging consul should always use 3 nodes

### DIFF
--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -307,13 +307,13 @@ jobs:
       - name: cf2
 
   - name: consul_z1
-    instances: 1
+    instances: 2
     networks:
       - name: cf1
         static_ips: (( static_ips(27, 28, 29) ))
 
   - name: consul_z2
-    instances: 0
+    instances: 1
     networks:
       - name: cf2
         static_ips: (( static_ips(27, 28, 29) ))


### PR DESCRIPTION
In order to vet that the current software will work in production, we need a 3 node consul staging to vet that certificates and consensus has not broken prior to prod deployment