### PR TITLE
Fix acceptance test failures expecting resilience

### DIFF
--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -241,19 +241,19 @@ jobs:
         static_ips: (( static_ips(1) ))
 
   - name: uaa_z2
-    instances: 0
+    instances: 1
 
   - name: api_z1
     instances: 1
 
   - name: api_z2
-    instances: 0
+    instances: 1
 
   - name: api_worker_z1
     instances: 1
 
   - name: api_worker_z2
-    instances: 0
+    instances: 1
 
   - name: router_z1
     instances: 1
@@ -262,7 +262,7 @@ jobs:
         static_ips: (( static_ips(5, 6, 15, 16, 17, 18, 19, 20) ))
 
   - name: router_z2
-    instances: 0
+    instances: 1
     networks:
       - name: cf2
         static_ips: (( static_ips(5, 6, 15, 16, 17, 18, 19, 20) ))
@@ -274,7 +274,7 @@ jobs:
     instances: 1
 
   - name: runner_z2
-    instances: 0
+    instances: 1
 
   - name: loggregator_z1
     instances: 0
@@ -319,13 +319,13 @@ jobs:
         static_ips: (( static_ips(27, 28, 29) ))
 
   - name: etcd_z1
-    instances: 1
+    instances: 2
     networks:
       - name: cf1
         static_ips: (( static_ips(10, 25) ))
 
   - name: etcd_z2
-    instances: 0
+    instances: 1
     networks:
       - name: cf2
         static_ips: (( static_ips(9) ))

--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -271,7 +271,7 @@ jobs:
     instances: 0
 
   - name: runner_z1
-    instances: 1
+    instances: 2
 
   - name: runner_z2
     instances: 1


### PR DESCRIPTION
Upstream has updated their acceptance tests to ensure that components are resilient, such as: ./src/github.com/cloudfoundry/cf-acceptance-tests/routing/session_affinity_test.go
