### PR TITLE
Remove redundancy in staging

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -54,7 +54,7 @@ update:
   max_in_flight: 1
   canary_watch_time: 30000-600000
   update_watch_time: 5000-600000
-  serial: false
+  serial: true
 
 resource_pools: (( merge ))
 

--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -241,19 +241,19 @@ jobs:
         static_ips: (( static_ips(1) ))
 
   - name: uaa_z2
-    instances: 1
+    instances: 0
 
   - name: api_z1
     instances: 1
 
   - name: api_z2
-    instances: 1
+    instances: 0
 
   - name: api_worker_z1
     instances: 1
 
   - name: api_worker_z2
-    instances: 1
+    instances: 0
 
   - name: router_z1
     instances: 1
@@ -262,7 +262,7 @@ jobs:
         static_ips: (( static_ips(5, 6, 15, 16, 17, 18, 19, 20) ))
 
   - name: router_z2
-    instances: 1
+    instances: 0
     networks:
       - name: cf2
         static_ips: (( static_ips(5, 6, 15, 16, 17, 18, 19, 20) ))
@@ -271,10 +271,10 @@ jobs:
     instances: 0
 
   - name: runner_z1
-    instances: 2
+    instances: 1
 
   - name: runner_z2
-    instances: 1
+    instances: 0
 
   - name: loggregator_z1
     instances: 0


### PR DESCRIPTION
Extra redundancy is causing issues with doppler without a z2 doppler. Smoke and acceptance tests pass.

This will fix random issues we have been seeing in staging for e/w.