### PR TITLE
Update the doppler port to 4443

### DIFF
--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -26,6 +26,9 @@ properties:
   logger_endpoint:
     port: 4443
 
+  doppler:
+    port: 4443
+    
   loggregator:
     blacklisted_syslog_ranges:
     - start: 10.9.0.0


### PR DESCRIPTION
the `/v2/info` api call is returning the wrong data, which is preventing admin-ui from consuming the firehose, which is preventing it from displaying diego cells.

cc: https://github.com/18F/cg-product/issues/183