### PR TITLE
Revert "Allow egress to monitoring subnets."

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -36,8 +36,6 @@ meta:
     - protocol: all
       destination: 10.10.30.0-10.10.31.255
     - protocol: all
-      destination: 10.99.31.0-10.99.32.255
-    - protocol: all
       destination: 10.10.100.0-10.10.101.255
   resource_key: (( merge ))
 


### PR DESCRIPTION
This reverts commit fab609e7452bb1bd48c94336fc3120198446bc9a.

This was the wrong approach--handling it better now in https://github.com/18F/cg-deploy-riemann-firehose-nozzle/pull/2.