### PR TITLE
Merge UAA groups.

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -331,6 +331,7 @@ properties:
     scim:
       userids_enabled: (( merge || true ))
       users: (( merge ))
+      groups: ~
       external_groups: ~
 
     jwt:


### PR DESCRIPTION
Allow creation of uaa scim groups on deploy, so that we can create all the uaa entities needed for the admin ui without running a separate errand.