### PR TITLE
add missing license key for newrelic on the cloud controller (#166)

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -191,6 +191,7 @@ properties:
     development_mode: false
 
     newrelic:
+      license_key: (( merge ))
       environment_name: (( meta.environment ))
       developer_mode: (( cc.development_mode ))
       monitor_mode: true


### PR DESCRIPTION
I'm seeing the staging cloud controller now in newrelic, let's merge this to master
