### PR TITLE
change asset base url to be environment specific

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -282,7 +282,7 @@ properties:
     protocol: https
     brand: oss
     brand_title: cloud.gov
-    asset_base_url: /resources/cg
+    asset_base_url: /resources/govcloud
     uaa_base: ~
     self_service_links_enabled: true
     signups_enabled: true


### PR DESCRIPTION
In order to enable a different login template in east (we'll override this setting in east secrets)

cc: https://github.com/18F/cg-uaa/pull/37