### PR TITLE
CF v252 release + misc updates

### DIFF
--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -604,6 +604,10 @@ jobs:
     networks:
       - name: cf1
     properties:
+      consul:
+        agent:
+          services:
+            loggregator_trafficcontroller: {}
       metron_agent:
         zone: z1
       traffic_controller:
@@ -619,6 +623,10 @@ jobs:
     networks:
       - name: cf2
     properties:
+      consul:
+        agent:
+          services:
+            loggregator_trafficcontroller: {}
       metron_agent:
         zone: z2
       traffic_controller:

--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -83,10 +83,21 @@ meta:
   - name: cloud_controller_clock
     release: (( meta.capi_release.name ))
 
-  nats_templates:
+  nats_z1_templates:
   - name: nats
     release: (( meta.release.name ))
-    consumes: {nats: nil}
+    consumes:
+      nats:
+        from: nats_z1
+  - name: nats_stream_forwarder
+    release: (( meta.release.name ))
+
+  nats_z2_templates:
+  - name: nats
+    release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z2
   - name: nats_stream_forwarder
     release: (( meta.release.name ))
 
@@ -273,7 +284,10 @@ jobs:
         zone: z2
 
   - name: nats_z1
-    templates: (( merge || meta.nats_templates meta.metron_agent_templates ))
+    provides:
+      nats:
+        as: nats_z1
+    templates: (( merge || meta.nats_z1_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: medium_z1
     networks:
@@ -285,7 +299,10 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: nats_z2
-    templates: (( merge || meta.nats_templates meta.metron_agent_templates ))
+    provides:
+      nats:
+        as: nats_z2
+    templates: (( merge || meta.nats_z2_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: medium_z2
     networks:

--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -53,7 +53,7 @@ meta:
   api_consul_services:
     cloud_controller_ng: {}
 
-  api_templates:
+  api_z1_templates:
   - name: consul_agent
     release: (( meta.consul_release.name ))
   - name: cloud_controller_ng
@@ -62,6 +62,32 @@ meta:
     release: (( meta.release.name ))
   - name: route_registrar
     release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z1
+  - {name: java-buildpack, release: java-buildpack}
+  - {name: java-offline-buildpack, release: java-offline-buildpack}
+  - {name: go-buildpack, release: go-buildpack}
+  - {name: binary-buildpack, release: binary-buildpack}
+  - {name: nodejs-buildpack, release: nodejs-buildpack}
+  - {name: ruby-buildpack, release: ruby-buildpack}
+  - {name: php-buildpack, release: php-buildpack}
+  - {name: python-buildpack, release: python-buildpack}
+  - {name: staticfile-buildpack, release: staticfile-buildpack}
+  - {name: dotnet-core-buildpack, release: dotnet-core-buildpack}
+
+  api_z2_templates:
+  - name: consul_agent
+    release: (( meta.consul_release.name ))
+  - name: cloud_controller_ng
+    release: (( meta.capi_release.name ))
+  - name: statsd-injector
+    release: (( meta.release.name ))
+  - name: route_registrar
+    release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z2
   - {name: java-buildpack, release: java-buildpack}
   - {name: java-offline-buildpack, release: java-offline-buildpack}
   - {name: go-buildpack, release: go-buildpack}
@@ -86,6 +112,9 @@ meta:
   nats_z1_templates:
   - name: nats
     release: (( meta.release.name ))
+    provides:
+      nats:
+        as: nats_z1
     consumes:
       nats:
         from: nats_z1
@@ -95,6 +124,9 @@ meta:
   nats_z2_templates:
   - name: nats
     release: (( meta.release.name ))
+    provides:
+      nats:
+        as: nats_z2
     consumes:
       nats:
         from: nats_z2
@@ -109,13 +141,27 @@ meta:
   - name: dea_logging_agent
     release: (( meta.release.name ))
 
-  router_templates:
+  router_z1_templates:
   - name: secureproxy
     release: secureproxy
   - name: consul_agent
     release: (( meta.consul_release.name ))
   - name: gorouter
     release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z1
+
+  router_z2_templates:
+  - name: secureproxy
+    release: secureproxy
+  - name: consul_agent
+    release: (( meta.consul_release.name ))
+  - name: gorouter
+    release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z2
 
   etcd_templates:
   - name: etcd
@@ -153,6 +199,9 @@ meta:
     release: (( meta.capi_release.name ))
   - name: route_registrar
     release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z1
 
   uaa_routes:
   - name: uaa
@@ -173,13 +222,29 @@ meta:
     #   name: uaa-healthcheck
     #   script_path: /var/vcap/jobs/uaa/bin/health_check
 
-  uaa_templates:
+  uaa_z1_templates:
   - name: uaa
     release: (( meta.custom_release.name ))
   - name: consul_agent
     release: (( meta.consul_release.name ))
   - name: route_registrar
     release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z1
+  - name: statsd-injector
+    release: (( meta.release.name ))
+
+  uaa_z2_templates:
+  - name: uaa
+    release: (( meta.custom_release.name ))
+  - name: consul_agent
+    release: (( meta.consul_release.name ))
+  - name: route_registrar
+    release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z2
   - name: statsd-injector
     release: (( meta.release.name ))
 
@@ -194,13 +259,27 @@ meta:
     uris:
     - (( "hm9000." .properties.domain ))
 
-  hm9000_templates:
+  hm9000_z1_templates:
   - name: consul_agent
     release: (( meta.consul_release.name ))
   - name: hm9000
     release: (( meta.release.name ))
   - name: route_registrar
     release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z1
+
+  hm9000_z2_templates:
+  - name: consul_agent
+    release: (( meta.consul_release.name ))
+  - name: hm9000
+    release: (( meta.release.name ))
+  - name: route_registrar
+    release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z2
 
   loggregator_templates:
   - name: consul_agent
@@ -226,7 +305,7 @@ meta:
     - (( "loggregator." .properties.domain ))
     - (( "loggregator." .meta.service_domain ))
 
-  loggregator_trafficcontroller_templates:
+  loggregator_trafficcontroller_z1_templates:
   - name: consul_agent
     release: (( meta.consul_release.name ))
   - name: loggregator_trafficcontroller
@@ -235,6 +314,22 @@ meta:
     release: (( meta.release.name ))
   - name: route_registrar
     release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z1
+
+  loggregator_trafficcontroller_z2_templates:
+  - name: consul_agent
+    release: (( meta.consul_release.name ))
+  - name: loggregator_trafficcontroller
+    release: (( meta.release.name ))
+  - name: metron_agent
+    release: (( meta.release.name ))
+  - name: route_registrar
+    release: (( meta.release.name ))
+    consumes:
+      nats:
+        from: nats_z2
 
   consul_templates:
   - name: consul_agent
@@ -284,9 +379,6 @@ jobs:
         zone: z2
 
   - name: nats_z1
-    provides:
-      nats:
-        as: nats_z1
     templates: (( merge || meta.nats_z1_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: medium_z1
@@ -299,9 +391,6 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: nats_z2
-    provides:
-      nats:
-        as: nats_z2
     templates: (( merge || meta.nats_z2_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: medium_z2
@@ -359,7 +448,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: uaa_z1
-    templates: (( merge || meta.uaa_templates meta.metron_agent_templates ))
+    templates: (( merge || meta.uaa_z1_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: large_z1
     networks:
@@ -379,7 +468,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: uaa_z2
-    templates: (( merge || meta.uaa_templates meta.metron_agent_templates ))
+    templates: (( merge || meta.uaa_z2_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: large_z2
     networks:
@@ -410,7 +499,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: hm9000_z1
-    templates: (( merge || meta.hm9000_templates meta.metron_agent_templates ))
+    templates: (( merge || meta.hm9000_z1_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: large_z1
     networks:
@@ -427,7 +516,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: hm9000_z2
-    templates: (( merge || meta.hm9000_templates meta.metron_agent_templates ))
+    templates: (( merge || meta.hm9000_z2_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: large_z2
     networks:
@@ -444,7 +533,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: api_z1
-    templates: (( merge || meta.api_templates meta.metron_agent_templates ))
+    templates: (( merge || meta.api_z1_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: large_z1
     networks:
@@ -461,7 +550,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: api_z2
-    templates: (( merge || meta.api_templates meta.metron_agent_templates ))
+    templates: (( merge || meta.api_z2_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: large_z2
     networks:
@@ -615,7 +704,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: loggregator_trafficcontroller_z1
-    templates: (( merge || meta.loggregator_trafficcontroller_templates ))
+    templates: (( merge || meta.loggregator_trafficcontroller_z1_templates ))
     instances: 1
     resource_pool: medium_z1
     networks:
@@ -634,7 +723,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: loggregator_trafficcontroller_z2
-    templates: (( merge || meta.loggregator_trafficcontroller_templates ))
+    templates: (( merge || meta.loggregator_trafficcontroller_z2_templates ))
     instances: 1
     resource_pool: medium_z2
     networks:
@@ -653,7 +742,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: router_z1
-    templates: (( merge || meta.router_templates meta.metron_agent_templates ))
+    templates: (( merge || meta.router_z1_templates meta.metron_agent_templates ))
     instances: 2
     resource_pool: router_z1
     networks:
@@ -669,7 +758,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: router_z2
-    templates: (( merge || meta.router_templates meta.metron_agent_templates ))
+    templates: (( merge || meta.router_z2_templates meta.metron_agent_templates ))
     instances: 1
     resource_pool: router_z2
     networks:

--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -688,6 +688,13 @@ jobs:
         zone: z1
       metron_agent:
         zone: z1
+      consul:
+          agent:
+            services:
+              doppler:
+                name: doppler
+                tags:
+                - z1
     update: (( merge || empty_hash ))
 
   - name: doppler_z2
@@ -701,6 +708,13 @@ jobs:
         zone: z2
       metron_agent:
         zone: z2
+      consul:
+          agent:
+            services:
+              doppler:
+                name: doppler
+                tags:
+                - z2
     update: (( merge || empty_hash ))
 
   - name: loggregator_trafficcontroller_z1

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -428,15 +428,16 @@ properties:
         authorities: routing.routes.read,routing.router_groups.read
         authorized-grant-types: client_credentials,refresh_token
         secret: (( merge ))
-      invite_app:
-        scope: scim.invite
-        authorized-grant-types: authorization_code
+      uaa_extras_app:
+        scope: scim.invite,password.write
+        authorized-grant-types: authorization_code,client_credentials
+        authorities: scim.read,password.write,uaa.admin
         secret: (( merge ))
-        redirect-uri: (( "https://invite." meta.service_domain "/oauth/login"))
+        redirect-uri: (( "https://account." meta.service_domain "/oauth/login"))
         name: Invite Users
         autoapprove: true
         show-on-homepage: true
-        app-launch-url: (( "https://invite." meta.service_domain ))
+        app-launch-url: (( "https://account." meta.service_domain "/invite"))
         app-icon: 'iVBORw0KGgoAAAANSUhEUgAAAHQAAAB0CAMAAABjROYVAAABwlBMVEUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADzhAbiAAAAlXRSTlMAAQIDBAUGBwgJCw0ODxAREhMUFRYXGBkaGxwdHh8gIiMlJicoKSorLC0uLzAxMjM0NTY3ODk7PEFCQ0ZHSUpLTE9QUVJWWFlbXF1fYmRnaWtsbW91d3h5fH6FhomLjI6PkZSVl5qbnZ6go6WmqKqrsLK0t7m6vMDBw8fIz9HT1dfZ2tze4OLk5ujp6+3v8fP19/n7/SSB24YAAAOhSURBVGje7drpXxJBGAfwH6ABFniWpFR2mJZlZdphapl2WGnaoZ12mh0mmUeaKV6ZpmmCz//bC0Ee3IPdZWd90f5e7WeZmS/u7jMzCIAdO3bs2Nmm+JtD0+skNOvToWY/I72vyKK88MTNomWyLEuBDbN4nSzMegAAvMtkaX57ALwki/Mc8JPl8aHZevQqQrGjtfqCPKEpqI3EqH7MxI7qxM9AjTFqGvF62S0e3ROvGsQvdFA8mhe3NtHS7UAvikf3S9BO8WiVBB0Vj3ZKUMoUjs5L0dOizSBJ0X7RaI8MSjkWFUwS+kws+lUWpYBI8yzJo2MCTc+KAkrt4tAQKaF0TJR5l5TRiKDbWk0qKK3mizCPkCpKf0vMN0ujKVCiC2abtRJCilKXw0zS0UVaUBpym2e6h0gFvbmWOLlYZJZZtJgYde2GBM0LRth7uWyOeYWXY7F0j5SH4Cpr0u1Mn3R282IMQg5F9jxrNJ6Vrpk1zob76Yc8Cvcwa7ZyKD3zMJ/ih91QQuF4yB+ylnTMW3ykBw4oo0AVe4ip12WUdL1nw6yd2TipiMI3wZqH/cZM/xQbZMKHVCicb/mbrDRinuKX6/VmHaigQBO/HR36zXu8f2PivCqKYjaPUEjnLjyTbxKS5jZ1NHnGnNO1xubPsa6DSbN4ChSOTtY1ek67eT4qqRTNKFATNbDaJa1jkeotr6ZGkTujeJ0U17FB1mVa8olBA4qMPjbEgoYtW4A/f58yYAQFWvmzfymVWcdbt8o00Iaiglf5E9Ub63jKt3cVMI7CH2ZDjarcWPcoazjpQzooXB/5oqj4aTKXL8UfFNYJzSjQxqfiMvk2xyMpbqdeFCf5iNflWrTw93UCZqDI4TPbG8m1c/Wwl2dVPs/rQpE5wIadKdxSnbPsxS9qq4M+FI7HvAbvsNpxJNXyI9Wq0okCDXzscEn89EG+RaB69TF0oyjhu2L6Vu0FvDW8OGnlAMxGsWuKVBPeCfNRZHxWM/syIAIF2pXNNg3djaEo/yNPLh2FOBQ7ZL866t4BkSgQGNhKDhRq7GocBYp6Oflur+aO6aCApz4UJSKKhuo8OrqlhwKANzvbq7NL+qiB2KiN2qiN2uh/hy7EDsrEo+Ux6hdGYkc/fKJN/2SMGsZ9sjwdid8BWJd9wHerzTHA+j81CADXrDWbNh6rVivN2/GHuXLRKnKB/RvE2TBiBTlcv+UrJldWrtife+VmuWDHjh07drYt/wDZpi7rUVKOBQAAAABJRU5ErkJggg=='
       dashboard_tile:
         name: Dashboard

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -191,6 +191,7 @@ properties:
     development_mode: false
 
     newrelic:
+      license_key: (( merge ))
       environment_name: (( meta.environment ))
       developer_mode: (( cc.development_mode ))
       monitor_mode: true

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -547,8 +547,10 @@ properties:
 
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
 
-    zones: (( merge || nil ))
-
+    zones:
+      internal:
+        hostnames:
+          - uaa.service.cf.internal
     authentication:
       policy:
         lockoutAfterFailures: 3 # Lock after 3 attempts to match FedRAMP requirement

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -318,6 +318,9 @@ properties:
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
 
   uaa:
+    ca_cert: (( merge ))
+    sslCertificate: (( merge ))
+    sslPrivateKey: (( merge ))
     servlet:
       session-cookie:
         max-age: 900 # 15 minutes per FedRAMP requirement

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -160,6 +160,8 @@ properties:
     broker_client_default_async_poll_interval_seconds: (( merge || 60 ))
     broker_client_max_async_poll_duration_minutes: (( merge || 10080 ))
 
+    mutal_tls: ~
+
     resource_pool:
       blobstore_type: (( merge || "fog" ))
       webdav_config: (( merge || properties.cc.webdav_config ))

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -160,7 +160,7 @@ properties:
     broker_client_default_async_poll_interval_seconds: (( merge || 60 ))
     broker_client_max_async_poll_duration_minutes: (( merge || 10080 ))
 
-    mutal_tls: ~
+    mutual_tls: ~
 
     resource_pool:
       blobstore_type: (( merge || "fog" ))

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -5,6 +5,7 @@ jobs:
   serial: true
   plan:
   - aggregate:
+    - get: master-bosh-root-cert
     - get: pipeline-tasks
     - get: cf-manifests-staging
       trigger: true
@@ -56,7 +57,7 @@ jobs:
       - name: cf-manifest
   - put: cf-deployment-staging
     params: &deploy-params
-      cert: common/boshCA.crt
+      cert: master-bosh-root-cert/master-bosh.crt
       manifest: cf-manifest/manifest.yml
       releases:
       - cf-release/*.tgz
@@ -99,7 +100,7 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: common
-      resource: common-staging
+      resource: master-bosh-root-cert
       passed: [deploy-cf-staging]
     - get: cf-deployment-staging
       trigger: true
@@ -138,7 +139,7 @@ jobs:
       BOSH_PASSWORD: {{cf-deployment-staging-bosh-password}}
       BOSH_DEPLOYMENT_NAME: {{cf-deployment-staging-bosh-deployment}}
       BOSH_ERRAND: smoke_tests
-      BOSH_CACERT: common/boshCA.crt
+      BOSH_CACERT: common/master-bosh.crt
   on_success:
     put: slack
     params:
@@ -164,7 +165,7 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: common
-      resource: common-staging
+      resource: master-bosh-root-cert
       passed: [smoke-tests-staging]
     - get: cf-deployment-staging
       passed: [smoke-tests-staging]
@@ -206,7 +207,7 @@ jobs:
       BOSH_PASSWORD: {{cf-deployment-staging-bosh-password}}
       BOSH_DEPLOYMENT_NAME: {{cf-deployment-staging-bosh-deployment}}
       BOSH_ERRAND: acceptance_tests
-      BOSH_CACERT: common/boshCA.crt
+      BOSH_CACERT: common/master-bosh.crt
   on_success:
     put: slack
     params:
@@ -231,6 +232,7 @@ jobs:
   serial: true
   plan:
   - aggregate:
+    - get: master-bosh-root-cert
     - get: pipeline-tasks
     - get: cf-manifests-prod
     - get: common
@@ -306,7 +308,7 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: common
-      resource: common-prod
+      resource: master-bosh-root-cert
       passed: [deploy-cf-prod]
     - get: cf-deployment-prod
       trigger: true
@@ -318,7 +320,7 @@ jobs:
       BOSH_PASSWORD: {{cf-deployment-prod-bosh-password}}
       BOSH_DEPLOYMENT_NAME: {{cf-deployment-prod-bosh-deployment}}
       BOSH_ERRAND: smoke_tests
-      BOSH_CACERT: common/boshCA.crt
+      BOSH_CACERT: common/master-bosh.crt
   on_success:
     put: slack
     params:
@@ -344,7 +346,7 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: common
-      resource: common-prod
+      resource: master-bosh-root-cert
       passed: [smoke-tests-prod]
     - get: cf-deployment-prod
       passed: [smoke-tests-prod]
@@ -357,7 +359,7 @@ jobs:
       BOSH_PASSWORD: {{cf-deployment-prod-bosh-password}}
       BOSH_DEPLOYMENT_NAME: {{cf-deployment-prod-bosh-deployment}}
       BOSH_ERRAND: acceptance_tests
-      BOSH_CACERT: common/boshCA.crt
+      BOSH_CACERT: common/master-bosh.crt
   on_success:
     put: slack
     params:
@@ -378,6 +380,15 @@ jobs:
       icon_url: {{slack-icon-url}}
 
 resources:
+- name: master-bosh-root-cert
+  type: s3
+  source:
+    access_key_id: {{ci-access-key-id}}
+    bucket: {{cf-private-prod-bucket}}
+    region_name: {{aws-region}}
+    secret_access_key: {{ci-secret-access-key}}
+    versioned_file: master-bosh.crt
+
 - name: pipeline-tasks
   type: git
   source:


### PR DESCRIPTION
These changes are required to deploy CF v252 along with the following secrets changes:

# CF secrets:
Add the following new keys:
```
# https://github.com/cloudfoundry/capi-release/blob/develop/docs/tls-configuration.md
cc:
  mutual_tls:
    ca_cert:
    public_cert:
    private_key:

# certstrap request-cert --passphrase '' --cn 'uaa.service.cf.internal'
uaa:
  ca_cert:
  sslCertificate:
  sslPrivateKey:
```
Completely regenerate the loggregator certs (this will replace existing certs and generate a new one for metron): https://github.com/cloudfoundry/loggregator/blob/develop/docs/cert-config.md

# Diego Secrets

Add / regenerate certs for the following keys:
```
# https://github.com/cloudfoundry/diego-release/blob/develop/docs/tls-configuration.md
property_overrides:
  auctioneer:
    ca_cert:
    server_cert:
    server_key:
    client_cert:
    client_key:
  bbs:
    auctioneer:
      require_tls: true
    ca_cert:
    server_cert:
    server_key:
    client_cert:
    client_key:
  rep:
    require_tls: true
    ca_cert:
    server_cert:
    server_key:
    client_cert:
    client_key:
  # https://github.com/cloudfoundry/capi-release/blob/develop/docs/tls-configuration.md
  tps:
    cc:
      ca_cert:
      client_cert:
      client_key:
```

In staging I used a single root CA to generate all certs, so the value of `ca_cert` in all components is the same.