### PR TITLE
Be explicit in the sandbox-bot client name

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -536,7 +536,7 @@ properties:
         refresh-token-validity: 259200
         secret: (( merge ))
         autoapprove: true
-      uaamonitor:
+      sandbox-bot:
         scope: cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read
         authorized-grant-types: authorization_code,client_credentials,refresh_token
         authorities: cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read


### PR DESCRIPTION
As part of https://github.com/18F/cg-sandbox-bot/pull/29 I updated the secrets to use this client name (and renamed the existing clients in staging and production) and rotated the client secret.

The corresponding secrets change for this has already been made.