### PR TITLE
community does not use the service domain

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -515,7 +515,7 @@ properties:
         access-token-validity: 600
         refresh-token-validity: 259200
         secret: (( merge ))
-        redirect-uri: (( "https://community." meta.service_domain "/auth/oauth2_basic/callback" ))
+        redirect-uri: https://community.app.cloud.gov/auth/oauth2_basic/callback
         autoapprove: true
       concourse-broker:
         scope: cloud_controller.read


### PR DESCRIPTION
Unsure if hardcoding this domain is a good idea or if I should add another meta key for the "app" domain to the manifest? 