### PR TITLE
use m4.large types for doppler only

### DIFF
--- a/cf-infrastructure-aws.yml
+++ b/cf-infrastructure-aws.yml
@@ -142,7 +142,7 @@ resource_pools:
 
   - name: large_z1
     cloud_properties:
-      instance_type: m4.large
+      instance_type: m3.large
       ephemeral_disk:
         size: 65_536
         type: gp2
@@ -151,6 +151,26 @@ resource_pools:
       key_name: (( meta.aws.key_name ))
 
   - name: large_z2
+    cloud_properties:
+      instance_type: m3.large
+      ephemeral_disk:
+        size: 65_536
+        type: gp2
+        encrypted: true
+      availability_zone: (( meta.zones.z2 ))
+      key_name: (( meta.aws.key_name ))
+
+  - name: doppler_z1
+    cloud_properties:
+      instance_type: m4.large
+      ephemeral_disk:
+        size: 65_536
+        type: gp2
+        encrypted: true
+      availability_zone: (( meta.zones.z1 ))
+      key_name: (( meta.aws.key_name ))
+
+  - name: doppler_z2
     cloud_properties:
       instance_type: m4.large
       ephemeral_disk:
@@ -280,11 +300,13 @@ jobs:
 
   - name: doppler_z1
     instances: 2
+    resource_pool: doppler_z1
     networks:
       - name: cf1
 
   - name: doppler_z2
     instances: 2
+    resource_pool: doppler_z2
     networks:
       - name: cf2
 


### PR DESCRIPTION
Until AWS case 2123159541 is resolved and we have a larger quota for m4.large types, only use them for the machines that really need it.