### PR TITLE
Use instance profiles for errand vms.

### DIFF
--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -66,6 +66,7 @@ compilation:
   cloud_properties:
     instance_type: c3.large
     availability_zone: (( meta.zones.z1 ))
+    iam_instance_profile: staging-bosh-compilation
     ephemeral_disk:
        size: 30000
        type: gp2
@@ -269,12 +270,14 @@ resource_pools:
         size: 10_240
         type: gp2
         encrypted: true
+      iam_instance_profile: staging-bosh-compilation
       availability_zone: (( meta.zones.z1 ))
       key_name: (( meta.aws.key_name ))
 
   - name: xlarge_errand
     cloud_properties:
       instance_type: c3.xlarge
+      iam_instance_profile: staging-bosh-compilation
       availability_zone: (( meta.zones.z1 ))
       key_name: (( meta.aws.key_name ))
 

--- a/cf-infrastructure-aws.yml
+++ b/cf-infrastructure-aws.yml
@@ -69,6 +69,7 @@ compilation:
   cloud_properties:
     instance_type: c3.large
     availability_zone: (( meta.zones.z1 ))
+    iam_instance_profile: production-bosh-compilation
     ephemeral_disk:
       size: 30000
       type: gp2
@@ -272,12 +273,14 @@ resource_pools:
         size: 10_240
         type: gp2
         encrypted: true
+      iam_instance_profile: production-bosh-compilation
       availability_zone: (( meta.zones.z1 ))
       key_name: (( meta.aws.key_name ))
 
   - name: xlarge_errand
     cloud_properties:
       instance_type: c3.xlarge
+      iam_instance_profile: production-bosh-compilation
       availability_zone: (( meta.zones.z1 ))
       key_name: (( meta.aws.key_name ))
 


### PR DESCRIPTION
Sigh. Errands need instance profiles too, because sometimes they want to write their logs to the blobstore. @LinuxBozo 

cc @cnelson, in case you have a better idea before we switch to cloud-config.