### PR TITLE
Reconcile staging and production router instance counts.

### DIFF
--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -318,13 +318,13 @@ jobs:
     instances: 0
 
   - name: router_z1
-    instances: 1
+    instances: 2
     networks:
       - name: cf1
         static_ips: (( static_ips(5, 6, 15, 16, 17, 18, 19, 20) ))
 
   - name: router_z2
-    instances: 0
+    instances: 1
     networks:
       - name: cf2
         static_ips: (( static_ips(5, 6, 15, 16, 17, 18, 19, 20) ))


### PR DESCRIPTION
So that we can understand downtime during deployments on staging.