### PR TITLE
Adding authority to edit

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -466,7 +466,7 @@ properties:
       dashboard:
         scope: cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read,scim.invite
         authorized-grant-types: authorization_code,client_credentials,refresh_token
-        authorities: uaa.none
+        authorities: uaa.admin
         override: true
         access-token-validity: 600
         refresh-token-validity: 259200


### PR DESCRIPTION
@jcscottiii  and I are getting `401` errors when we trigger the `scim.invite_user` scope. Looking at  the `uaa_extras` app, we noticed the `authority` contains the `uaa.admin` permission. 

We would like to add this `authority` to the dashboard app to see if it will fix the current issue with triggering `invite.user` from the dashboard.
