### PR TITLE
Move updated healthcheck to production

### DIFF
--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -1007,6 +1007,11 @@ properties:
     debug_addr: (( merge || nil ))
     drain_wait: (( merge || nil ))
     skip_oauth_tls_verification: (( merge || nil ))
+    # This must be set to 0 to get the behaivor we want according to the rules outlined here:
+    # https://github.com/cloudfoundry-incubator/routing-release#configure-load-balancer-healthchecks-for-gorouter
+    # Any other setting and the health check will respond 200 for this period of time, but the router will not actually be up
+    # TODO: Revisit this setting once https://github.com/cloudfoundry/gorouter/issues/160 is closed
+    load_balancer_healthy_threshold: 0
 
   routing_api:
     enabled: (( merge || nil ))
@@ -1015,23 +1020,13 @@ properties:
     listen_port: 80
     proxy_port: 85
 
-    # Custom gorouter health check
-    # Verify that gorouter returns expected 404
-    # TODO(jmcarp) find a better solution
+    # Expose gorouter health check for ELB
+    # For this to work, router.load_balancer_healthy_threshold must be set to 0
     custom_server_config: |-
       server {
         listen 81;
-
         location / {
-          error_page 404 =200 /health;
-          proxy_pass http://localhost:85/;
-          proxy_intercept_errors on;
-          proxy_redirect off;
-        }
-
-        location /health {
           proxy_pass http://localhost:8080/health;
-          internal;
         }
       }
 

--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -1015,12 +1015,23 @@ properties:
     listen_port: 80
     proxy_port: 85
 
-    # Expose gorouter health check for ELB
+    # Custom gorouter health check
+    # Verify that gorouter returns expected 404
+    # TODO(jmcarp) find a better solution
     custom_server_config: |-
       server {
         listen 81;
+
         location / {
+          error_page 404 =200 /health;
+          proxy_pass http://localhost:85/;
+          proxy_intercept_errors on;
+          proxy_redirect off;
+        }
+
+        location /health {
           proxy_pass http://localhost:8080/health;
+          internal;
         }
       }
 

--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -1015,6 +1015,15 @@ properties:
     listen_port: 80
     proxy_port: 85
 
+    # Expose gorouter health check for ELB
+    custom_server_config: |-
+      server {
+        listen 81;
+        location / {
+          proxy_pass http://localhost:8080/health;
+        }
+      }
+
   syslog_daemon_config: ~
 
   nfs_server: (( meta.nfs_server ))


### PR DESCRIPTION
Tested this in staging by recreating the routers several times while continually hitting a test app.  I saw no 5xx errors during the tests from nginx or the ELB.

