### PR TITLE
Add authorities required for user invite

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -466,7 +466,7 @@ properties:
       dashboard:
         scope: cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read,scim.invite
         authorized-grant-types: authorization_code,client_credentials,refresh_token
-        authorities: uaa.none
+        authorities: uaa.admin,scim.invite,password.write
         override: true
         access-token-validity: 600
         refresh-token-validity: 259200


### PR DESCRIPTION
Based on trying a number of combinations, the required authorities to get UAA invites to work are `uaa.admin,scim.invite,password.write`.

![explain](https://cloud.githubusercontent.com/assets/1332366/25678443/c0e280ce-3017-11e7-993f-65d270b3bf44.png)
