### PR TITLE
Add meta.environment for the sake of newrelic

### DIFF
--- a/cf-secrets-example.external.yml
+++ b/cf-secrets-example.external.yml
@@ -1,4 +1,6 @@
 # External secrets that are not easily rotated
+meta:
+  environment: DEPLOYMENT_NAME
 
 properties:
   cc:


### PR DESCRIPTION
Not sure if there is a better way to do this. ~~I have to look through the manifests again to see if `meta.environment` is being used in `*.main.yml` at all.~~ It is being used in both, so it needs to be in both. but maybe we can revisit this during the CF secrets refactoring @jmcarp mentioned on #213.

Let's add this to the list of CF configuration work, @wjwoodson.