### PR TITLE
Drop unused certificate and missing credentials.

### DIFF
--- a/generate-all-certificates.sh
+++ b/generate-all-certificates.sh
@@ -56,9 +56,7 @@ then
   jq -r '
     .resources[] |
     select( .name == "master-bosh-root-cert" ) |
-    @sh "export AWS_ACCESS_KEY_ID=\(.source.access_key_id)
-    export AWS_SECRET_ACCESS_KEY=\(.source.secret_access_key)
-    export AWS_DEFAULT_REGION=\(.source.region_name)
+    @sh "export AWS_DEFAULT_REGION=\(.source.region_name)
     export CA_CERT=\(.source.versioned_file)
     export CA_BUCKET=\(.source.bucket)"
   '
@@ -71,9 +69,7 @@ then
   jq -r '
     .resources[] |
     select( .name == "common-masterbosh" ) |
-    @sh "export AWS_ACCESS_KEY_ID=\(.source.access_key_id)
-    export AWS_SECRET_ACCESS_KEY=\(.source.secret_access_key)
-    export AWS_DEFAULT_REGION=\(.source.region)
+    @sh "export AWS_DEFAULT_REGION=\(.source.region)
     export PASSPHRASE=\(.source.secrets_passphrase)
     export CA_KEY_ENCRYPTED=\(.source.bosh_cert)
     export CA_BUCKET=\(.source.bucket_name)"
@@ -135,17 +131,6 @@ mv -f ${depot_path}/$consul_server_cn.csr ${depot_path}/consul_server.csr
 mv -f ${depot_path}/$consul_server_cn.crt ${depot_path}/consul_server.crt
 certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name 'consul agent'
 certstrap --depot-path "${depot_path}" sign consul_agent --CA "${local_ca_cert_name}"
-
-echo -e "${GREEN}Creating${NC} HM9000 key and certificate pairs"
-hm9000_server_cn=listener-hm9000.service.cf.internal
-hm9000_server_domain='*.listener-hm9000.service.cf.internal'
-certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name $hm9000_server_cn --domain "${hm9000_server_domain},${hm9000_server_cn}"
-certstrap --depot-path "${depot_path}" sign $hm9000_server_cn --CA "${local_ca_cert_name}"
-mv -f ${depot_path}/$hm9000_server_cn.key ${depot_path}/hm9000_server.key
-mv -f ${depot_path}/$hm9000_server_cn.csr ${depot_path}/hm9000_server.csr
-mv -f ${depot_path}/$hm9000_server_cn.crt ${depot_path}/hm9000_server.crt
-certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name 'hm9000_client'
-certstrap --depot-path "${depot_path}" sign hm9000_client --CA "${local_ca_cert_name}"
 
 echo -e "${GREEN}Creating${NC} UAA key and certificate pairs"
 uaa_server_cn="uaa.service.cf.internal"


### PR DESCRIPTION
hm9000 isn't a thing, and aws credentials on resources are getting dropped