### PR TITLE
Remove reference to ssh-proxy uaa client from external secrets example

### DIFF
--- a/cf-secrets-example.external.yml
+++ b/cf-secrets-example.external.yml
@@ -67,8 +67,6 @@ properties:
         secret:
       uaa-token-audit:
         secret:
-      ssh-proxy:
-        secret:
       uaa_extras_app:
         secret:
       logsearch_firehose_ingestor:


### PR DESCRIPTION
This is https://github.com/18F/cg-deploy-cf/pull/231 but against the correct branch.