### PR TITLE
Drop ASGs from CF manifest

### DIFF
--- a/cf-infrastructure-aws-development.yml
+++ b/cf-infrastructure-aws-development.yml
@@ -20,12 +20,6 @@ properties:
   logger_endpoint:
     port: 443
 
-  loggregator:
-    <<: (( merge ))
-    blacklisted_syslog_ranges:
-    - start: 10.8.0.0
-      end: 10.8.255.255
-
   cc:
     resource_pool:
       blobstore_type: fog

--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -20,12 +20,6 @@ properties:
   logger_endpoint:
     port: 443
 
-  loggregator:
-    <<: (( merge ))
-    blacklisted_syslog_ranges:
-    - start: 10.9.0.0
-      end: 10.9.255.255
-
   cc:
     resource_pool:
       blobstore_type: fog

--- a/cf-infrastructure-aws.yml
+++ b/cf-infrastructure-aws.yml
@@ -23,16 +23,6 @@ properties:
   logger_endpoint:
     port: 443
 
-  loggregator:
-    <<: (( merge ))
-    # don't allow drains to RFC1918 private networks
-    blacklisted_syslog_ranges:
-    - start: 10.0.0.0
-      end: 10.255.255.255
-    - start: 172.16.0.0
-      end: 172.31.255.255
-    - start: 192.168.0.0
-      end: 192.168.255.255
   cc:
     resource_pool:
       blobstore_type: fog

--- a/cf-infrastructure-aws.yml
+++ b/cf-infrastructure-aws.yml
@@ -25,10 +25,14 @@ properties:
 
   loggregator:
     <<: (( merge ))
+    # don't allow drains to RFC1918 private networks
     blacklisted_syslog_ranges:
-    - start: 10.10.0.0
-      end: 10.10.255.255
-
+    - start: 10.0.0.0
+      end: 10.255.255.255
+    - start: 172.16.0.0
+      end: 172.31.255.255
+    - start: 192.168.0.0
+      end: 192.168.255.255
   cc:
     resource_pool:
       blobstore_type: fog

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -34,13 +34,20 @@ properties:
     <<: (( merge ))
     maxRetainedLogMessages: 100
     debug: (( merge || false ))
-    blacklisted_syslog_ranges: ~
     outgoing_dropsonde_port: 8081
 
   doppler:
     maxRetainedLogMessages: 100
     debug: (( merge || false ))
-    blacklisted_syslog_ranges: ~
+    # don't allow drains to RFC1918 private networks
+    blacklisted_syslog_ranges:
+    - start: 10.0.0.0
+      end: 10.255.255.255
+    - start: 172.16.0.0
+      end: 172.31.255.255
+    - start: 192.168.0.0
+      end: 192.168.255.255
+
     unmarshaller_count: (( merge || 5 ))
     port: 443
 

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -209,6 +209,12 @@ properties:
       description: "Cloud Foundry Linux-based filesystem"
     default_stack: "cflinuxfs2"
 
+    # security groups are managed via terraform
+    # see terraform/asg.tf in this repo
+    security_group_definitions: []
+    default_running_security_groups: []
+    default_staging_security_groups: []
+
     allowed_cors_domains: (( merge || [] ))
     thresholds:
       api:

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -8,35 +8,6 @@ meta:
       total_service_keys: 1000
       non_basic_services_allowed: true
       total_routes: 1000
-  default_security_group_definitions:
-  - name: public_networks
-    rules:
-    - protocol: all
-      destination: 0.0.0.0-9.255.255.255
-    - protocol: all
-      destination: 11.0.0.0-169.253.255.255
-    - protocol: all
-      destination: 169.255.0.0-172.15.255.255
-    - protocol: all
-      destination: 172.32.0.0-192.167.255.255
-    - protocol: all
-      destination: 192.169.0.0-255.255.255.255
-  - name: dns
-    rules:
-    - protocol: tcp
-      destination: 0.0.0.0/0
-      ports: '53'
-    - protocol: udp
-      destination: 0.0.0.0/0
-      ports: '53'
-  - name: trusted_local_networks
-    rules:
-    - protocol: all
-      destination: 10.10.20.0-10.10.21.255
-    - protocol: all
-      destination: 10.10.30.0-10.10.31.255
-    - protocol: all
-      destination: 10.10.100.0-10.10.101.255
   resource_key: (( merge ))
 
 properties:
@@ -237,10 +208,6 @@ properties:
     - name: "cflinuxfs2"
       description: "Cloud Foundry Linux-based filesystem"
     default_stack: "cflinuxfs2"
-
-    security_group_definitions: (( merge || meta.default_security_group_definitions ))
-    default_running_security_groups: (( merge || ["public_networks", "dns", "trusted_local_networks"] ))
-    default_staging_security_groups: (( merge || ["public_networks", "dns", "trusted_local_networks"] ))
 
     allowed_cors_domains: (( merge || [] ))
     thresholds:

--- a/generate-development.sh
+++ b/generate-development.sh
@@ -28,5 +28,3 @@ spiff merge \
   $SCRIPTPATH/cf-infrastructure-aws-development.yml \
   $SECRETS \
   > $MANIFEST
-
-sed -i -- 's/10\.10\./10\.8\./g' $MANIFEST

--- a/generate-staging.sh
+++ b/generate-staging.sh
@@ -29,4 +29,3 @@ spiff merge \
   $SECRETS \
   > $MANIFEST
 
-sed -i -- 's/10.10/10.9/g' $MANIFEST


### PR DESCRIPTION
These are managed by terraform now.

@jmcarp, we should roll this out after finishing the ASG deploy tomorrow.