### PR TITLE
Add scim.read to dashboard

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -480,7 +480,7 @@ properties:
       dashboard:
         scope: cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read,scim.invite
         authorized-grant-types: authorization_code,client_credentials,refresh_token
-        authorities: uaa.none,scim.invite,cloud_controller.admin
+        authorities: uaa.none,scim.invite,cloud_controller.admin,scim.read
         override: true
         access-token-validity: 600
         refresh-token-validity: 259200


### PR DESCRIPTION
In order to query for users to see if they exist before trying to create an account for a given e-mail, we need to have the `scim.read` property on the dashboard client.

Needed for https://github.com/18F/cg-dashboard/pull/1123