### PR TITLE
Revert "bump a semver resource anytime we update buildpacks in prod"

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1111,48 +1111,6 @@ jobs:
       channel: {{slack-channel}}
       username: {{slack-username}}
       icon_url: {{slack-icon-url}}
-- name: buildpacks-updated
-  plan:
-  - aggregate:
-    - get: java-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-    - get: go-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-    - get: binary-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-    - get: nodejs-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-    - get: ruby-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-    - get: php-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-    - get: python-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-    - get: staticfile-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-    - get: dotnet-core-buildpack-release
-      trigger: true
-      passed:
-      - deploy-cf-production
-  - put: buildpacks-updated
-    params:
-      bump: patch
 
 resources:
 - name: master-bosh-root-cert
@@ -1427,14 +1385,6 @@ resources:
   source:
     interval: 10m
 
-- name: buildpacks-updated
-  type: semver-iam
-  source:
-    bucket: cg-semver
-    driver: s3
-    key: buildpacks-updated
-    region_name: us-gov-west-1
-
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -1455,11 +1405,6 @@ resource_types:
   type: docker-image
   source:
     repository: 18fgsa/s3-resource
-
-- name: semver-iam
-  type: docker-image
-  source:
-    repository: governmentpaas/semver-resource
 
 groups:
 - name: all
@@ -1486,7 +1431,6 @@ groups:
   - smoke-tests-production
   - uaa-smoke-tests-production
   - tic-smoke-tests-production
-  - buildpacks-updated
 - name: development
   jobs:
   - deploy-cf-development
@@ -1515,4 +1459,3 @@ groups:
   - smoke-tests-production
   - uaa-smoke-tests-production
   - tic-smoke-tests-production
-  - buildpacks-updated


### PR DESCRIPTION
This reverts commit db786cf344977dcdb127068097f799d8020bcbb2.

@jcscottiii: We don't need to bump the semver resource now that the buildpack notifier is stateful, right?

cc @rogeruiz 