### PR TITLE
Enable uniqueness restriction on refresh tokens.

### DIFF
--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -348,6 +348,9 @@ properties:
     jwt:
       signing_key: (( merge ))
       verification_key: (( merge ))
+      revocable: true
+      refresh:
+        unique: true
 
     cc:
       client_secret: (( merge ))


### PR DESCRIPTION
So that creating a new refresh token revokes all existing refresh tokens for that client-user combination. Gets us part of the way to compliance with AC-10.