### PR TITLE
Limit uaa refresh token uniqueness to production.

### DIFF
--- a/cf-infrastructure-aws-development.yml
+++ b/cf-infrastructure-aws-development.yml
@@ -17,9 +17,6 @@ properties:
   <<: (( merge ))
   template_only: (( merge ))
 
-  logger_endpoint:
-    port: 443
-
   cc:
     resource_pool:
       blobstore_type: fog
@@ -358,9 +355,3 @@ jobs:
     networks:
       - name: cf2
         static_ips: (( static_ips(9) ))
-
-  - name: acceptance_tests
-    instances: 1
-
-  - name: smoke_tests
-    instances: 1

--- a/cf-infrastructure-aws-staging.yml
+++ b/cf-infrastructure-aws-staging.yml
@@ -17,9 +17,6 @@ properties:
   <<: (( merge ))
   template_only: (( merge ))
 
-  logger_endpoint:
-    port: 443
-
   cc:
     resource_pool:
       blobstore_type: fog
@@ -357,9 +354,3 @@ jobs:
     networks:
       - name: cf2
         static_ips: (( static_ips(9) ))
-
-  - name: acceptance_tests
-    instances: 1
-
-  - name: smoke_tests
-    instances: 1

--- a/cf-infrastructure-aws.yml
+++ b/cf-infrastructure-aws.yml
@@ -20,8 +20,11 @@ properties:
   <<: (( merge ))
   template_only: (( merge ))
 
-  logger_endpoint:
-    port: 443
+  uaa:
+    jwt:
+      revocable: true
+      refresh:
+        unique: true
 
   cc:
     resource_pool:
@@ -357,9 +360,3 @@ jobs:
     networks:
       - name: cf2
         static_ips: (( static_ips(9) ))
-
-  - name: acceptance_tests
-    instances: 1
-
-  - name: smoke_tests
-    instances: 1

--- a/cf-jobs.yml
+++ b/cf-jobs.yml
@@ -806,7 +806,8 @@ properties:
   metron_endpoint:
     shared_secret: (( .properties.loggregator_endpoint.shared_secret ))
 
-  logger_endpoint: ~
+  logger_endpoint:
+    port: 443
 
   cc: (( merge ))
   ccdb: (( merge ))

--- a/cf-properties.yml
+++ b/cf-properties.yml
@@ -348,9 +348,6 @@ properties:
     jwt:
       signing_key: (( merge ))
       verification_key: (( merge ))
-      revocable: true
-      refresh:
-        unique: true
 
     cc:
       client_secret: (( merge ))


### PR DESCRIPTION
So that we don't break parallel acceptance tests on staging.