### PR TITLE
Revert unique uaa refresh tokens.

### DIFF
--- a/bosh/opsfiles/uaa-refresh-unique.yml
+++ b/bosh/opsfiles/uaa-refresh-unique.yml
@@ -1,9 +1,0 @@
-# Use unique refresh tokens
-# Note: Apply in production only to avoid breaking staging acceptance tests
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/jwt/revocable?
-  value: true
-
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/jwt/refresh?/unique
-  value: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -596,7 +596,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/uaa-customized.yml
       - cf-manifests/bosh/opsfiles/uaa-branding.yml
       - cf-manifests/bosh/opsfiles/uaa-login.yml
-      - cf-manifests/bosh/opsfiles/uaa-refresh-unique.yml
       - cf-manifests/bosh/opsfiles/uaa-saml.yml
       - cf-manifests/bosh/opsfiles/newrelic.yml
       - cf-manifests/bosh/opsfiles/encryption.yml


### PR DESCRIPTION
Because it breaks tests and multi-instance applications.