### PR TITLE
No need to drop deprecated saml properties.

### DIFF
--- a/bosh/opsfiles/uaa-saml.yml
+++ b/bosh/opsfiles/uaa-saml.yml
@@ -1,18 +1,11 @@
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/saml/activeKeyId?
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/saml/activeKeyId
   value: ((uaa-saml-active-key-id))
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/saml/keys?
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/saml/keys
   value: ((uaa-saml-keys))
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/saml/providers?
   value: ((uaa-saml-providers))
-
-# Remove deprecated properties
-- type: remove
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/saml/serviceProviderKey
-
-- type: remove
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/saml/serviceProviderCertificate


### PR DESCRIPTION
Since they've now been dropped by upstream cf-deployment as well.