### PR TITLE
Append rds ca cert instead of replace and disable app identity.

### DIFF
--- a/bosh/opsfiles/diego-rds-certs.yml
+++ b/bosh/opsfiles/diego-rds-certs.yml
@@ -1,7 +1,6 @@
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers?/trusted_ca_certificates
-  value:
-  - &rds-ca |-
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers?/trusted_ca_certificates/-
+  value: &rds-ca |-
     # rds-ca-2015-root.pem
     -----BEGIN CERTIFICATE-----
     MIID9DCCAtygAwIBAgIBQjANBgkqhkiG9w0BAQUFADCBijELMAkGA1UEBhMCVVMx
@@ -99,9 +98,8 @@
     -----END CERTIFICATE-----
 
 - type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/containers?/trusted_ca_certificates
-  value:
-  - *rds-ca
+  path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/containers?/trusted_ca_certificates/-
+  value: *rds-ca
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties?/cflinuxfs2-rootfs/trusted_certs

--- a/bosh/opsfiles/disable-instance-identity.yml
+++ b/bosh/opsfiles/disable-instance-identity.yml
@@ -1,0 +1,6 @@
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/executor/instance_identity_ca_cert
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/executor/instance_identity_key
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates/0

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -61,6 +61,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/log-levels.yml
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
+      - cf-manifests/bosh/opsfiles/disable-instance-identity.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
@@ -322,6 +323,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/log-levels.yml
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
+      - cf-manifests/bosh/opsfiles/disable-instance-identity.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
@@ -660,6 +662,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/log-levels.yml
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
+      - cf-manifests/bosh/opsfiles/disable-instance-identity.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml


### PR DESCRIPTION
Pairing with @wjwoodson 

Latest cf-deployment enables diego app instance identity, but this feature requires container networking, which we're not using yet. We should disable instance identity until we have time to evaluate and enable supporting features.