### PR TITLE
Add optional whitelist to uaa client audit.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -233,6 +233,7 @@ jobs:
       UAA_CLIENT_SECRET: ((uaa-audit-client-secret-development))
       CF_API_URL: ((cf-api-url-development))
       GATEWAY_HOST: ((gateway-host-development))
+      WHITELIST: ((uaa-audit-whitelist-development))
 
 - name: tic-smoke-tests-development
   plan:
@@ -406,6 +407,7 @@ jobs:
       UAA_CLIENT_SECRET: ((uaa-audit-client-secret-staging))
       CF_API_URL: ((cf-api-url-staging))
       GATEWAY_HOST: ((gateway-host-staging))
+      WHITELIST: ((uaa-audit-whitelist-staging))
 
 - name: tic-smoke-tests-staging
   plan:
@@ -793,6 +795,7 @@ jobs:
       UAA_CLIENT_SECRET: ((uaa-audit-client-secret-production))
       CF_API_URL: ((cf-api-url-production))
       GATEWAY_HOST: ((gateway-host-production))
+      WHITELIST: ((uaa-audit-whitelist-production))
 
 - name: tic-smoke-tests-production
   plan:

--- a/ci/uaa-client-audit.sh
+++ b/ci/uaa-client-audit.sh
@@ -54,8 +54,17 @@ cg_clients=$(cat cf-manifests/bosh/opsfiles/clients.yml \
 # Diff existing clients against expected
 clients=$(uaac clients | grep -v ":" | sed 's/ //g')
 
+whitelist="admin"
+if [ -n "${WHITELIST:-}" ]; then
+  whitelist=$(cat <<EOF
+${whitelist}
+$(echo "${WHITELIST}" | tr " " "\n")
+EOF
+)
+fi
+
 known_clients=$(cat <<EOF
-admin
+${whitelist}
 ${service_instance_guids}
 ${service_binding_guids}
 ${service_key_guids}


### PR DESCRIPTION
Because some hand-propped clients are still in use.