### PR TITLE
[WIP] Proxy to s3 for acme http challenge tokens.

### DIFF
--- a/bosh/opsfiles/secureproxy.yml
+++ b/bosh/opsfiles/secureproxy.yml
@@ -22,6 +22,20 @@
               proxy_pass http://localhost:8080/health;
             }
           }
+
+          server {
+            listen 8081;
+            location ~ (^/.well-known/acme-challenge/.*) {
+              resolver 8.8.8.8;
+
+              proxy_set_header Host s3-us-gov-west-1.amazonaws.com;
+              proxy_set_header Authorization $http_authorization;
+              proxy_set_header Connection '';
+
+              set $s3_host 's3-us-gov-west-1.amazonaws.com';
+              proxy_pass https://$s3_host/((challenge_bucket))$1;
+            }
+          }
         tic:
           host_whitelist:
           - hostname: api.((system_domain))

--- a/bosh/varsfiles/terraform.yml
+++ b/bosh/varsfiles/terraform.yml
@@ -22,3 +22,5 @@ external_locket_database_name: locketdb
 external_locket_database_address: ((terraform_outputs.cf_rds_host))
 external_locket_database_username: ((terraform_outputs.cf_rds_username))
 external_locket_database_password: ((terraform_outputs.cf_rds_password))
+
+challenge_bucket: ((terraform_outputs.challenge_bucket))


### PR DESCRIPTION
Use secureproxy as a challenge server for the alb custom domains broker.