### PR TITLE
Drop unused locket link.

### DIFF
--- a/bosh/opsfiles/locket-link.yml
+++ b/bosh/opsfiles/locket-link.yml
@@ -1,0 +1,2 @@
+- type: remove
+  path: /instance_groups/name=diego-api/jobs/name=locket/consumes

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -68,6 +68,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/name-development.yml
       - cf-manifests/bosh/opsfiles/scaling-development.yml
+      - cf-manifests/bosh/opsfiles/locket-link.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -332,6 +333,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/name-staging.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
+      - cf-manifests/bosh/opsfiles/locket-link.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -677,6 +679,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/name-production.yml
       - cf-manifests/bosh/opsfiles/scaling-production.yml
+      - cf-manifests/bosh/opsfiles/locket-link.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
Revert after https://github.com/cloudfoundry/cf-deployment/pull/525 gets merged and released.