### PR TITLE
Drop redundant last check metric.

### DIFF
--- a/ci/uaa-client-audit.sh
+++ b/ci/uaa-client-audit.sh
@@ -106,4 +106,3 @@ done
 uaa_url=$(echo "${UAA_URL}" | sed 's/https:\/\///')
 curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/uaa_client_audit/uaa_url/${uaa_url}"
 curl --data-binary @${metrics} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/uaa_client_audit/uaa_url/${uaa_url}"
-echo "uaa_client_audit_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/uaa_client_audit/instance/lastcheck"


### PR DESCRIPTION
Now that the push gateway emits the last push timestamp for each group,
we don't need to emit custom last check metrics.

Goes with https://github.com/18F/cg-deploy-prometheus/pull/90.