### PR TITLE
consolidate secrets buckets

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -939,7 +939,7 @@ resources:
 - name: master-bosh-root-cert
   type: s3-iam
   source:
-    bucket: {{cf-private-production-bucket}}
+    bucket: {{cf-private-bucket}}
     region_name: {{aws-region}}
     versioned_file: master-bosh.crt
 
@@ -1016,21 +1016,21 @@ resources:
 - name: common-development
   type: s3-iam
   source:
-    bucket: {{cf-private-development-bucket}}
+    bucket: {{cf-private-bucket}}
     versioned_file: cf-development.yml
     region_name: {{aws-region}}
 
 - name: common-staging
   type: s3-iam
   source:
-    bucket: {{cf-private-staging-bucket}}
+    bucket: {{cf-private-bucket}}
     versioned_file: cf-staging.yml
     region_name: {{aws-region}}
 
 - name: common-production
   type: s3-iam
   source:
-    bucket: {{cf-private-production-bucket}}
+    bucket: {{cf-private-bucket}}
     versioned_file: cf-production.yml
     region_name: {{aws-region}}
 

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -9,12 +9,7 @@ diego-manifests-git-url: https://github.com/18F/cg-deploy-diego.git
 diego-release-repo-git-url: https://github.com/cloudfoundry/diego-release.git
 diego-release-repo-git-branch: master
 diego-manifests-git-branch-development: master
-cf-private-development-bucket: SECURE_BUCKET
-cf-private-development-passphrase: PASSWORD
-cf-private-staging-bucket: SECURE_BUCKET
-cf-private-staging-passphrase: PASSWORD
-cf-private-prod-bucket: SECURE_BUCKET
-cf-private-prod-passphrase: PASSWORD
+cf-private-bucket: SECURE_BUCKET
 development-bosh-target: 192.168.2.2
 development-bosh-username: admin
 development-bosh-password: PASSWORD


### PR DESCRIPTION
The staging secrets bucket causes confusion and so @rogeruiz suggested that I go fix that up in all our deployments. As soon as this is approved, I will fly the pipeline for this. The secrets files should all be copied over and ready to go.

@jmcarp , there seems to be some stuff in the pipeline there that doesn't reflect what is in the concourse secrets file:
```
  resource cf-acceptance-tests has changed:
  name: cf-acceptance-tests
  type: git
  source:
-   branch: service-discovery-protocol
-   uri: https://github.com/jmcarp/cf-acceptance-tests.git
+   branch: master
+   uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
```
I plan on leaving that alone, but wanted to point it out in case it was something that you wanted to update.
