### PR TITLE
Make SpaceDeveloper able to set network policies

### DIFF
--- a/bosh/opsfiles/cf-networking.yml
+++ b/bosh/opsfiles/cf-networking.yml
@@ -1,0 +1,8 @@
+# CF Networking Release
+# https://github.com/cloudfoundry/cf-networking-release
+
+# Grant all SpaceDevelopers permissions to configure network policies
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/enable_space_developer_self_service?
+  value: true
+

--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -157,8 +157,3 @@
   path: /instance_groups/name=diego-platform-cell/jobs/name=route_emitter/properties/internal_routes?
   value:
     enabled: true
-
-# Grant all SpaceDevelopers permissions to configure network policies
-- type: replace
-  path: /instance_groups/name=api/jobs/name=policy-server/properties/enable_space_developer_self_service?
-  value: true

--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -157,3 +157,8 @@
   path: /instance_groups/name=diego-platform-cell/jobs/name=route_emitter/properties/internal_routes?
   value:
     enabled: true
+
+# Grant all SpaceDevelopers permissions to configure network policies
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/enable_space_developer_self_service?
+  value: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -71,6 +71,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-development.yml
+      - cf-manifests/bosh/opsfiles/cf-networking.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -338,6 +339,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
+      - cf-manifests/bosh/opsfiles/cf-networking.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -686,6 +688,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-production.yml
+      - cf-manifests/bosh/opsfiles/cf-networking.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
This patch adds the property mentioned in the CF docs around giving
SpaceDevelopers the ability to use container networking without
operators having to add this to their scope specifically.

See docs here:
https://docs.cloudfoundry.org/devguide/deploy-apps/cf-networking.html#grant
See spec for `policy-server` here:
https://github.com/cloudfoundry/cf-networking-release/blob/master/jobs/policy-server/spec#L52-L54