### PR TITLE
Rename client secret for CredHub awareness

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -21,7 +21,7 @@
     override: true
     authorized-grant-types: client_credentials
     authorities: cloud_controller.global_auditor
-    secret: ((cdn-broker-client-secret))
+    secret: ((/cf/clients/cdn-broker-secret))
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/s3-broker?


### PR DESCRIPTION
This patch renames this client secret to have an absolute path in order
to avoid having variable files for each different environment.

We're doing this to avoid having operation or variable files which determine the Cloud Foundry environment. We want to standardize the path of the client secrets that can be used across deployments in the same CredHub.

```
/cf/clients/${name-of-client}-secret
```


Pairing with @jontours on this one. 18F/cf-domain-broker-alb#9