### PR TITLE
Drop pinned dns aliases release version.

### DIFF
--- a/bosh/opsfiles/kubernetes-dns.yml
+++ b/bosh/opsfiles/kubernetes-dns.yml
@@ -9,12 +9,3 @@
         source:
           type: dns
           recursors: ((kubernetes_recursors))
-
-# TODO: Delete after cf-deployment releases latest alises release
-- type: replace
-  path: /releases/name=bosh-dns-aliases?
-  value:
-    name: bosh-dns-aliases
-    version: 0.0.3
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-    sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc


### PR DESCRIPTION
**Not ready for merge yet!** Should be ready once cf-deployment cuts release 3.2.0 with the latest version of bosh-dns-aliases-release.

Pinning will be unnecessary once upstream cf-deployment upgrades beyond
version 0.0.2.