### PR TITLE
Add nginx buildpack to releases and buildpacks.

### DIFF
--- a/bosh/opsfiles/nginx-buildpack.yml
+++ b/bosh/opsfiles/nginx-buildpack.yml
@@ -1,0 +1,19 @@
+- type: replace
+  path: /releases/-
+  value:
+    name: nginx-buildpack
+    url: https://github.com/18F/nginx-buildpack-release/releases/download/1.0.0/nginx-buildpack-1.0.0.tgz
+    version: 1
+    sha1sum: cc43c99279d93c0c4e7015c52a33c031adbce969
+
+- type: replace
+  path: /instance_groups/name=api/jobs/-
+  value:
+    name: nginx-buildpack
+    release: nginx-buildpack
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: nginx_buildpack
+    package: nginx-buildpack

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -70,6 +70,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
+      - cf-manifests/bosh/opsfiles/nginx-buildpack.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -340,6 +341,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
+      - cf-manifests/bosh/opsfiles/nginx-buildpack.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -691,6 +693,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-production.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
+      - cf-manifests/bosh/opsfiles/nginx-buildpack.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
Uses https://github.com/jmcarp/nginx-buildpack-release, which I can transfer over to 18F. Ideally pivotal would maintain this bosh release, but it's literally an empty job with a single package that wraps the buildpack archive.