### PR TITLE
Name bosh links to avoid ambiguity.

### DIFF
--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -118,6 +118,8 @@
         client_key: ((silk_daemon.private_key))
     - name: silk-cni
       release: silk
+      consumes:
+        vpa: {from: vpa-platform}
 
 # Set platform cell instance profile and placement tag
 - type: replace
@@ -131,9 +133,11 @@
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/provides?/vpa
   value: {as: vpa-tenant}
-
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=silk-daemon/consumes?/vpa
+  value: {from: vpa-tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=silk-cni/consumes?/vpa
   value: {from: vpa-tenant}
 
 # Add platform cells to DNS aliases

--- a/bosh/opsfiles/volume-services.yml
+++ b/bosh/opsfiles/volume-services.yml
@@ -128,6 +128,8 @@
         client_key: ((silk_daemon.private_key))
     - name: silk-cni
       release: silk
+      consumes:
+        vpa: {from: vpa-sandbox}
 
 # Set sandbox cell placement tag
 - type: replace


### PR DESCRIPTION
So that we can deploy cf-deployment v3.2.0.