### PR TITLE
Doppler is at 80% memory usage

### DIFF
--- a/bosh/opsfiles/doppler.yml
+++ b/bosh/opsfiles/doppler.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=doppler/vm_type
+  value: m4.xlarge

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -70,6 +70,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
+      - cf-manifests/bosh/opsfiles/doppler.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -336,6 +337,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
+      - cf-manifests/bosh/opsfiles/doppler.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
* Overriding 'minimal' doesn't make sense as it is overly used
* Adding a new type in cloud config is not something currently useful across deployments
* Concerned about the impact of memory usage during rollouts where nodes go down