### PR TITLE
Add emphemeral_disk_size to smoke-tests

### DIFF
--- a/bosh/opsfiles/smoke-tests.yml
+++ b/bosh/opsfiles/smoke-tests.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /instance_groups/name=smoke-tests/vm_type
+  value: m3.large
+- type: replace
+  path: /instance_groups/name=smoke-tests/vm_resources?/emphemeral_disk_size
+  value: 20480

--- a/bosh/opsfiles/smoke-tests.yml
+++ b/bosh/opsfiles/smoke-tests.yml
@@ -1,6 +1,6 @@
 - type: replace
   path: /instance_groups/name=smoke-tests/vm_type
-  value: m3.large
+  value: m4.large
 - type: replace
   path: /instance_groups/name=smoke-tests/vm_resources?/emphemeral_disk_size
   value: 20480

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -337,6 +337,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/doppler.yml
+      - cf-manigests/bosh/opsfiles/smoke-tests.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -685,6 +686,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-production.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/doppler.yml
+      - cf-manigests/bosh/opsfiles/smoke-tests.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
Our smoke-test VMs were filling up on disk_space and causing all sorts
of alerts from going off. This should fix that. _Still need to add this to the actual pipeline though._