### PR TITLE
Upgrade to CF 4.x

### DIFF
--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -1,0 +1,56 @@
+# This file exists to remove CredHub Secured Service Credential Delivery which
+# is now on by default in cf-deployment >=4.x.
+
+- type: remove
+  path: /instance_groups/name=credhub
+
+- type: remove
+  path: /variables/name=credhub_database_password
+
+- type: remove
+  path: /variables/name=credhub_encryption_password
+
+- type: remove
+  path: /variables/name=credhub_admin_client_secret
+
+- type: remove
+  path: /variables/name=credhub_ca
+
+- type: remove
+  path: /variables/name=credhub_tls
+
+- type: remove
+  path: /releases/name=credhub
+
+- type: remove
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=credhub.service.cf.internal
+
+- type: remove
+  path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/name=credhub
+
+- type: remove
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cc_service_key_client
+
+- type: remove
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/credhub_admin_client
+
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/credhub_api
+
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/uaa/clients/cc_service_key_client
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs
+  value: |
+    ((application_ca.certificate))
+    ((uaa_ca.certificate))
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates
+  value:
+    - ((application_ca.certificate))
+    - ((uaa_ca.certificate))
+
+- type: remove
+  path: /variables/name=uaa_clients_cc_service_key_client_secret

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -2,9 +2,6 @@
 # is now on by default in cf-deployment >=4.x.
 
 - type: remove
-  path: /variables/name=credhub_database_password
-
-- type: remove
   path: /variables/name=credhub_encryption_password
 
 - type: remove

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -2,9 +2,6 @@
 # is now on by default in cf-deployment >=4.x.
 
 - type: remove
-  path: /instance_groups/name=credhub
-
-- type: remove
   path: /variables/name=credhub_database_password
 
 - type: remove
@@ -21,6 +18,9 @@
 
 - type: remove
   path: /releases/name=credhub
+
+- type: remove
+  path: /instance_groups/name=credhub
 
 - type: remove
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=credhub.service.cf.internal

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -22,8 +22,8 @@
 - type: remove
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=credhub.service.cf.internal
 
-- type: remove
-  path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/name=credhub
+#- type: remove
+#  path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/name=credhub
 
 - type: remove
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cc_service_key_client

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -31,9 +31,6 @@
 - type: remove
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/credhub_api
 
-#- type: remove
-#  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/uaa/clients/cc_service_key_client
-
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs
   value: |

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -31,8 +31,8 @@
 - type: remove
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/credhub_api
 
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/uaa/clients/cc_service_key_client
+#- type: remove
+#  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/uaa/clients/cc_service_key_client
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -22,9 +22,6 @@
 - type: remove
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=credhub.service.cf.internal
 
-#- type: remove
-#  path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/name=credhub
-
 - type: remove
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cc_service_key_client
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -70,6 +70,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
+      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -338,6 +338,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/doppler.yml
+      - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -338,7 +338,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/doppler.yml
-      - cf-manifests/bosh/opsfiles/smoke-tests.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -338,6 +338,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/doppler.yml
+      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
This body of work is for upgrading to cf-deployment >=4.x.

> Removing CredHub from the CF deployment;

> This removes Secure Service Credentials Delivery from cf-deployment
> \>=4.x. It's not something we want to turn on right now as it has
> potential impacts for our service brokers that we're not aware of. And
> this way of removing it was what was outlined from the BOSH/Pivotal developers.
>
> :eyes: https://cloudfoundry.slack.com/archives/C2U7KA7M4/p1536849821000100