### PR TITLE
Remove vm_type and replace it with vm_resources

### DIFF
--- a/bosh/opsfiles/smoke-tests.yml
+++ b/bosh/opsfiles/smoke-tests.yml
@@ -1,6 +1,12 @@
-- type: replace
+- type: remove
   path: /instance_groups/name=smoke-tests/vm_type
-  value: m4.large
+
 - type: replace
   path: /instance_groups/name=smoke-tests/vm_resources?/emphemeral_disk_size
   value: 20480
+- type: replace
+  path: /instance_groups/name=smoke-tests/vm_resources?/ram
+  value: 8192
+- type: replace
+  path: /instance_groups/name=smoke-tests/vm_resources?/cpu
+  value: 2


### PR DESCRIPTION
BOSH is complaining about this so we gotta be super specific.

```
 Instance group 'smoke-tests' can only specify one of 'resource_pool', 'vm_type' or 'vm_resources' keys.
```