### PR TITLE
BOSH can't look things up

### DIFF
--- a/bosh/opsfiles/doppler.yml
+++ b/bosh/opsfiles/doppler.yml
@@ -1,3 +1,12 @@
-- type: replace
+- type: remove
   path: /instance_groups/name=doppler/vm_type
-  value: m4.xlarge
+
+- type: replace
+  path: /instance_groups/name=doppler/vm_resources?/ephemeral_disk_size
+  value: 10240
+- type: replace
+  path: /instance_groups/name=doppler/vm_resources?/ram
+  value: 16384
+- type: replace
+  path: /instance_groups/name=doppler/vm_resources?/cpu
+  value: 4


### PR DESCRIPTION
BOSH can't look via `vm_type` so we'll use `vm_resources` instead to
make doppler VMs m4.xlarge.

Cherry-picking this out of `upgrade-4.x` branch cause it's a different body of work.