### PR TITLE
Upgrade 4.5.0

### DIFF
--- a/bosh/opsfiles/disable-rlp.yml
+++ b/bosh/opsfiles/disable-rlp.yml
@@ -1,0 +1,2 @@
+- type: remove
+  path: /instance_groups/jobs/name=reverse_log_proxy_gateway

--- a/bosh/opsfiles/disable-rlp.yml
+++ b/bosh/opsfiles/disable-rlp.yml
@@ -1,2 +1,2 @@
 - type: remove
-  path: /instance_groups/jobs/name=reverse_log_proxy_gateway
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -71,6 +71,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/disable-rlp.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
Disables RPI.  Keeping WIP in case there any other issues for this final 4.x release.