### PR TITLE
Revert default stemcell to trusty. Xenial still needs tested.

### DIFF
--- a/bosh/opsfiles/use-trusty-stemcell.yml
+++ b/bosh/opsfiles/use-trusty-stemcell.yml
@@ -1,0 +1,12 @@
+# Default upstream uses xenial. Revert to trusty for now
+- path: /stemcells/alias=default/os
+  type: replace
+  value: ubuntu-trusty
+- path: /addons/name=loggregator_agent/include/stemcell/-
+  type: replace
+  value:
+    os: ubuntu-trusty
+- path: /addons/name=bpm/include/stemcell/-
+  type: replace
+  value:
+    os: ubuntu-trusty

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,6 +43,7 @@ jobs:
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
       - cf-deployment-transition/remove-routing-components-for-transition.yml
+      - cf-manifests/bosh/opsfiles/use-trusty-stemcell.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
       - cf-manifests/bosh/opsfiles/kubernetes-dns.yml
       - cf-manifests/bosh/opsfiles/consul-azs.yml
@@ -310,6 +311,7 @@ jobs:
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
       - cf-deployment-transition/remove-routing-components-for-transition.yml
+      - cf-manifests/bosh/opsfiles/use-trusty-stemcell.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
       - cf-manifests/bosh/opsfiles/kubernetes-dns.yml
       - cf-manifests/bosh/opsfiles/consul-azs.yml
@@ -660,6 +662,7 @@ jobs:
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
       - cf-deployment-transition/remove-routing-components-for-transition.yml
+      - cf-manifests/bosh/opsfiles/use-trusty-stemcell.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
       - cf-manifests/bosh/opsfiles/kubernetes-dns.yml
       - cf-manifests/bosh/opsfiles/consul-azs.yml


### PR DESCRIPTION
Upstream has now defaulted to using Xenial stemcells. We don't have a current plan for hardening xenial, and the testing required, so keep using trusty for now.