### PR TITLE
Add support for `cf v3-push-zdt` command.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -42,6 +42,8 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
+      - cf-deployment/operations/experimental/add-deployment-updater.yml
+      - cf-deployment/operations/experimental/add-deployment-updater-postgres.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/use-trusty-stemcell.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,7 +43,7 @@ jobs:
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
       - cf-deployment/operations/experimental/add-deployment-updater.yml
-      - cf-deployment/operations/experimental/add-deployment-updater-postgres.yml
+      - cf-deployment/operations/experimental/add-deployment-updater-external-db.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/use-trusty-stemcell.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
@@ -311,6 +311,8 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
+      - cf-deployment/operations/experimental/add-deployment-updater.yml
+      - cf-deployment/operations/experimental/add-deployment-updater-external-db.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/use-trusty-stemcell.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
@@ -654,6 +656,8 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
+      - cf-deployment/operations/experimental/add-deployment-updater.yml
+      - cf-deployment/operations/experimental/add-deployment-updater-external-db.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/use-trusty-stemcell.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml


### PR DESCRIPTION
At least one of our pipelines is in a broken state due to capi no longer supporting `env` parameter.  Using this new feature as a workaround.