### PR TITLE
Disables log cache as default logging solution

### DIFF
--- a/ci/acceptance-tests-config.sh
+++ b/ci/acceptance-tests-config.sh
@@ -12,6 +12,7 @@ cat > integration-config/integration_config.json <<EOF
   "include_container_networking": true,
   "include_service_discovery": true,
   "include_docker": true,
-  "skip_ssl_validation": false
+  "skip_ssl_validation": false,
+  "use_log_cache": false
 }
 EOF


### PR DESCRIPTION
To enable the log-cache api we need to open up the endpoint to the public internet.  This gets the tests passing until we decide on that.