### PR TITLE
[WIP] - Make call to fs3 job

### DIFF
--- a/bosh/opsfiles/diego-rds-certs.yml
+++ b/bosh/opsfiles/diego-rds-certs.yml
@@ -106,13 +106,13 @@
   value: *rds-ca
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties?/cflinuxfs2-rootfs/trusted_certs
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties?/cflinuxfs3-rootfs/trusted_certs
   value: *rds-ca
 
 - type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=cflinuxfs2-rootfs-setup/properties?/cflinuxfs2-rootfs/trusted_certs
+  path: /instance_groups/name=diego-platform-cell/jobs/name=cflinuxfs3-rootfs-setup/properties?/cflinuxfs3-rootfs/trusted_certs
   value: *rds-ca
 
 - type: replace
-  path: /instance_groups/name=diego-sandbox-cell/jobs/name=cflinuxfs2-rootfs-setup/properties?/cflinuxfs2-rootfs/trusted_certs
+  path: /instance_groups/name=diego-sandbox-cell/jobs/name=cflinuxfs3-rootfs-setup/properties?/cflinuxfs3-rootfs/trusted_certs
   value: *rds-ca

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -32,7 +32,7 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/credhub_api
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties/cflinuxfs2-rootfs/trusted_certs
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
   value: |
     ((application_ca.certificate))
     ((uaa_ca.certificate))

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -40,7 +40,6 @@
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates
   value:
-    - ((application_ca.certificate))
     - ((uaa_ca.certificate))
 
 - type: remove

--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -14,8 +14,8 @@
     networks:
     - name: default
     jobs:
-    - name: cflinuxfs2-rootfs-setup
-      release: cflinuxfs2
+    - name: cflinuxfs3-rootfs-setup
+      release: cflinuxfs3
     - name: garden
       release: garden-runc
       properties:
@@ -28,7 +28,7 @@
           deny_networks:
           - 0.0.0.0/0
           persistent_image_list:
-          - "/var/vcap/packages/cflinuxfs2/rootfs.tar"
+          - "/var/vcap/packages/cflinuxfs3/rootfs.tar"
           network_plugin: /var/vcap/packages/runc-cni/bin/garden-external-networker
           network_plugin_extra_args:
           - --configFile=/var/vcap/jobs/garden-cni/config/adapter.json
@@ -42,7 +42,7 @@
               client_cert: "((diego_bbs_client.certificate))"
               client_key: "((diego_bbs_client.private_key))"
             preloaded_rootfses:
-            - cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar
+            - cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar
             require_tls: true
             ca_cert: "((service_cf_internal_ca.certificate))"
             server_cert: "((diego_rep_agent_v2.certificate))"

--- a/bosh/opsfiles/volume-services.yml
+++ b/bosh/opsfiles/volume-services.yml
@@ -24,8 +24,8 @@
     networks:
     - name: default
     jobs:
-    - name: cflinuxfs2-rootfs-setup
-      release: cflinuxfs2
+    - name: cflinuxfs3-rootfs-setup
+      release: cflinuxfs3
     - name: garden
       release: garden-runc
       properties:
@@ -38,7 +38,7 @@
           deny_networks:
           - 0.0.0.0/0
           persistent_image_list:
-          - "/var/vcap/packages/cflinuxfs2/rootfs.tar"
+          - "/var/vcap/packages/cflinuxfs3/rootfs.tar"
           network_plugin: /var/vcap/packages/runc-cni/bin/garden-external-networker
           network_plugin_extra_args:
           - --configFile=/var/vcap/jobs/garden-cni/config/adapter.json
@@ -52,7 +52,7 @@
               client_cert: "((diego_bbs_client.certificate))"
               client_key: "((diego_bbs_client.private_key))"
             preloaded_rootfses:
-            - cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar
+            - cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar
             require_tls: true
             ca_cert: "((service_cf_internal_ca.certificate))"
             server_cert: "((diego_rep_agent_v2.certificate))"


### PR DESCRIPTION
Supports upgrade to 7.0+.  Volume services is broke now without this change (or at least in theory).  UPDATE: the issues volume services are having _is_ related to `cf-deployment.ym` 7.0+, but the problem most likely lies within the volume services release itself.