### PR TITLE
Reorder buildpacks to cflinuxfs3 from cflinuxfs2

### DIFF
--- a/bosh/opsfiles/buildpacks.yml
+++ b/bosh/opsfiles/buildpacks.yml
@@ -1,0 +1,43 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/
+  value:
+  - name: staticfile_buildpack
+    package: staticfile-buildpack-cflinuxfs3
+  - name: java_buildpack
+    package: java-buildpack-cflinuxfs3
+  - name: ruby_buildpack
+    package: ruby-buildpack-cflinuxfs3
+  - name: dotnet_core_buildpack
+    package: dotnet-core-buildpack-cflinuxfs3
+  - name: nodejs_buildpack
+    package: nodejs-buildpack-cflinuxfs3
+  - name: go_buildpack
+    package: go-buildpack-cflinuxfs3
+  - name: python_buildpack
+    package: python-buildpack-cflinuxfs3
+  - name: php_buildpack
+    package: php-buildpack-cflinuxfs3
+  - name: nginx_buildpack
+    package: nginx-buildpack-cflinuxfs3
+  - name: r_buildpack
+    package: r-buildpack-cflinuxfs3
+  - name: binary_buildpack
+    package: binary-buildpack-cflinuxfs3
+  - name: staticfile_buildpack
+    package: staticfile-buildpack-cflinuxfs2
+  - name: java_buildpack
+    package: java-buildpack-cflinuxfs2
+  - name: ruby_buildpack
+    package: ruby-buildpack-cflinuxfs2
+  - name: dotnet_core_buildpack
+    package: dotnet-core-buildpack-cflinuxfs2
+  - name: nodejs_buildpack
+    package: nodejs-buildpack-cflinuxfs2
+  - name: go_buildpack
+    package: go-buildpack-cflinuxfs2
+  - name: python_buildpack
+    package: python-buildpack-cflinuxfs2
+  - name: php_buildpack
+    package: php-buildpack-cflinuxfs2
+  - name: binary_buildpack
+    package: binary-buildpack-cflinuxfs2


### PR DESCRIPTION
Upstream already set up the default stack to cflinuxfs3, but our buildpack order was also coming from upstream which prioritizes cflinuxfs2. This patch prioritizes cflinuxfs3 so that it will truly by the default stack.