### PR TITLE
Double request timeout

### DIFF
--- a/bosh/opsfiles/routing.yml
+++ b/bosh/opsfiles/routing.yml
@@ -1,0 +1,7 @@
+# Routing Release
+# https://github.com/cloudfoundry/routing-release
+
+# Set global router timeout (request start to last byte sent) to 1800 seconds
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/request_timeout_in_seconds
+  value: 1800

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -72,6 +72,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/routing.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
Double the request_timeout_in_seconds from 900 to 1800. This setting is the total time of an active request processing.