### PR TITLE
Rename resource to Xenial

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -18,7 +18,7 @@ jobs:
       trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-development
-    - get: cf-stemcell
+    - get: cf-stemcell-xenial
       trigger: true
     - get: uaa-customized-release
       trigger: true
@@ -33,7 +33,7 @@ jobs:
       - uaa-customized-release/*.tgz
       - cg-s3-secureproxy-release/*.tgz
       stemcells:
-      - cf-stemcell/*.tgz
+      - cf-stemcell-xenial/*.tgz
       ops_files:
       - cf-deployment/operations/rename-network-and-deployment.yml
       - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
@@ -291,7 +291,7 @@ jobs:
       trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-staging
-    - get: cf-stemcell
+    - get: cf-stemcell-xenial
       trigger: true
     - get: uaa-customized-release
       trigger: true
@@ -519,7 +519,7 @@ jobs:
       trigger: true
     - get: cf-deployment
       passed: [deploy-cf-staging]
-    - get: cf-stemcell
+    - get: cf-stemcell-xenial
       passed: [deploy-cf-staging]
     - get: uaa-customized-release
       passed: [deploy-cf-staging]
@@ -575,7 +575,7 @@ jobs:
       trigger: true
     - get: cf-deployment
       passed: [smoke-tests-staging]
-    - get: cf-stemcell
+    - get: cf-stemcell-xenial
       passed: [smoke-tests-staging]
     - get: uaa-customized-release
       passed: [smoke-tests-staging]
@@ -632,7 +632,7 @@ jobs:
     - get: common-production
     - get: terraform-yaml
       resource: terraform-yaml-production
-    - get: cf-stemcell
+    - get: cf-stemcell-xenial
       passed: [acceptance-tests-staging]
       trigger: true
     - get: uaa-customized-release
@@ -721,7 +721,7 @@ jobs:
     - get: common-production
     - get: terraform-yaml
       resource: terraform-yaml-production
-    - get: cf-stemcell
+    - get: cf-stemcell-xenial
       passed: [plan-cf-production]
     - get: uaa-customized-release
       passed: [plan-cf-production]
@@ -1024,7 +1024,7 @@ resources:
     versioned_file: cf-production.yml
     region_name: {{aws-region}}
 
-- name: cf-stemcell
+- name: cf-stemcell-xenial
   type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent


### PR DESCRIPTION
Concourse didn't like that the resource named changed but the version number wasn't high enough to trigger a new get the latest version. So it complained that it couldn't find a version `3xxx` of Xenial. When Xenial is just a `25x` 😂 lol