### PR TITLE
Update diego-rds-certs.yml

### DIFF
--- a/bosh/opsfiles/diego-rds-certs.yml
+++ b/bosh/opsfiles/diego-rds-certs.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers?/trusted_ca_certificates/-
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/containers?/trusted_ca_certificates/-
   value: &rds-ca |-
     # rds-ca-2015-root.pem
     -----BEGIN CERTIFICATE-----
@@ -98,5 +98,5 @@
     -----END CERTIFICATE-----
 
 - type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/containers?/trusted_ca_certificates/-
+  path: /instance_groups/name=diego-platform-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/containers?/trusted_ca_certificates/-
   value: *rds-ca


### PR DESCRIPTION
Place the RDS root certificates under the right job according to the docs: https://docs.cloudfoundry.org/running/trusted-system-certificates.html.

@bengerman13 and I are guessing the underlying configuration spec changed awhile ago and we haven't noticed since there is a Java TLS problem when trying to connect to AWS RDS. We checked for the root certificates in a running container and they don't exist.