### PR TITLE
convert trusted_certs to an array, so it's easier to manipulate

### DIFF
--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -18,10 +18,10 @@
       release: cflinuxfs3
       properties:
         cflinuxfs3-rootfs:
-          trusted_certs: |
-            ((application_ca.certificate))
-            ((credhub_ca.certificate))
-            ((uaa_ca.certificate))
+          trusted_certs:
+          - ((application_ca.certificate))
+          - ((credhub_ca.certificate))
+          - ((uaa_ca.certificate))
     - name: garden
       release: garden-runc
       properties:


### PR DESCRIPTION
Fixes #428 which broke because this should've been [an array](https://github.com/cloudfoundry/cf-deployment/blob/master/cf-deployment.yml#L1445-L1448).