### PR TITLE
set max app disk size for workers, too

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -11,5 +11,9 @@
   value: 4096
 
 - type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
+  value: 4096
+
+- type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/client_max_body_size?
   value: "1536M"


### PR DESCRIPTION
This implements the fix recommended in cloudfoundry/cloud_controller_ng#1405