### PR TITLE
add opsfile back in to make concourse happy

### DIFF
--- a/bosh/opsfiles/pin-routing-release.yml
+++ b/bosh/opsfiles/pin-routing-release.yml
@@ -1,0 +1,11 @@
+# Remove this file once issues here: 	
+# https://cloudfoundry.slack.com/archives/CFX13JK7B/p1564068847018600	
+# are resolved	
+- type: replace	
+  path: /releases/name=routing?	
+  value:	
+    name: routing	
+    version: "0.188.0"	
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.188.0"	
+    sha1: "d3420851c470790e8980ff0c506f75e3e52c15d9" 	
+


### PR DESCRIPTION
the build is currently failing looking for this file. It's not referenced anywhere else in this repo that I can find, so I *think* bosh or concourse is trying to do some clever diff. 
I believe the fix is to add this file back in, run the deploy once more, then remove the file. 