### PR TITLE
temporarily use generated user

### DIFF
--- a/ci/acceptance-tests-config.sh
+++ b/ci/acceptance-tests-config.sh
@@ -6,7 +6,7 @@ cat > integration-config/integration_config.json <<EOF
   "apps_domain": "${APPS_DOMAIN}",
   "admin_user": "${ADMIN_USER}",
   "admin_password": "${ADMIN_PASSWORD}",
-  "use_existing_user": true,
+  "use_existing_user": false,
   "existing_user": "${EXISTING_USER}",
   "existing_user_password": "${EXISTING_USER_PASSWORD}",
   "include_container_networking": true,


### PR DESCRIPTION
there's a bug in the logic about when to add a user to a space in the acceptance test setup. This works around that until we can get it addressed.
cloudfoundry-incubator/cf-test-helpers#46