### PR TITLE
scale logging a bit to handle arbitrary spikes from noisy neighbours.

### DIFF
--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -9,4 +9,7 @@
   value: 12
 - type: replace
   path: /instance_groups/name=doppler/instances
-  value: 5
+  value: 7
+- type: replace
+  path: /instance_groups/name=log-api/instances
+  value: 4


### PR DESCRIPTION
Increase doppler VMs by 2 and bring log-api up to 4.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>