### PR TITLE
faster deployments.

### DIFF
--- a/bosh/opsfiles/use-create-swap-delete.yml
+++ b/bosh/opsfiles/use-create-swap-delete.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /update/vm_strategy?
+  value: create-swap-delete

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -67,6 +67,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
+      - cf-manifests/bosh/opsfiles/use-create-swap-delete.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -394,6 +395,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/use-create-swap-delete.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -741,6 +743,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/use-create-swap-delete.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- use `create-swap-delete` instead of `delete-create` for much faster deployments.
- this should bring deployment times down by at least half of what it is now.

## security considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>